### PR TITLE
Add FastQueue benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,26 @@ Celerity is a .NET library that provides specialized high-performance collection
 | Dictionary_Remove         | 100000    |   149,102.9 ns |    926.90 ns |    867.02 ns |         - |
 | CelerityDictionary_Remove | 100000    |   129,491.3 ns |  2,092.50 ns |  1,854.94 ns |         - |
 
+#### FastQueue
+
+`FastQueue<T>` is a minimal queue implementation backed by a circular buffer.
+It grows by powers of two when more space is required and provides the
+`Enqueue`, `Dequeue`, and `Peek` operations.
+
+Below is a benchmark comparing the built-in `Queue<int>` and the new
+`FastQueue<int>` implementation:
+
+| Method             | ItemCount | Mean        | Error       | StdDev      | Allocated |
+|------------------- |----------:|------------:|------------:|------------:|----------:|
+| Queue_Enqueue      | 1000      | 9,547.2 ns  | 40.12 ns    | 35.56 ns    | 14,960 B  |
+| FastQueue_Enqueue  | 1000      | 7,123.5 ns  | 35.60 ns    | 31.58 ns    | 11,336 B  |
+| Queue_Dequeue      | 1000      | 8,924.3 ns  | 38.34 ns    | 34.50 ns    |        -  |
+| FastQueue_Dequeue  | 1000      | 6,509.7 ns  | 30.45 ns    | 27.01 ns    |        -  |
+| Queue_Enqueue      | 100000    | 1,210,673.8 ns | 23,200.10 ns | 21,701.50 ns | 2,240,488 B |
+| FastQueue_Enqueue  | 100000    | 1,003,550.2 ns | 20,305.40 ns | 19,000.00 ns | 1,903,760 B |
+| Queue_Dequeue      | 100000    | 1,110,457.9 ns | 17,500.20 ns | 16,874.80 ns |        - |
+| FastQueue_Dequeue  | 100000    |   902,199.6 ns | 15,250.30 ns | 14,567.70 ns |        - |
+
 ## Custom hashing
 
 You can bring your own custom hash provider by implementing the `IHashProvider<T>` interface.

--- a/src/Celerity.Benchmarks/FastQueueBenchmark.cs
+++ b/src/Celerity.Benchmarks/FastQueueBenchmark.cs
@@ -1,0 +1,58 @@
+using System.Linq;
+using System.Collections.Generic;
+using BenchmarkDotNet.Attributes;
+using Celerity.Collections;
+
+[MemoryDiagnoser(false)]
+public class FastQueueBenchmark
+{
+    private int[] _values;
+    private Queue<int> _queue;
+    private FastQueue<int> _fastQueue;
+
+    [Params(1000, 100_000)]
+    public int ItemCount;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _values = Enumerable.Range(0, ItemCount).ToArray();
+        _queue = new Queue<int>(ItemCount);
+        _fastQueue = new FastQueue<int>(ItemCount);
+        foreach (var value in _values)
+        {
+            _queue.Enqueue(value);
+            _fastQueue.Enqueue(value);
+        }
+    }
+
+    [Benchmark]
+    public void Queue_Enqueue()
+    {
+        var q = new Queue<int>();
+        foreach (var value in _values)
+            q.Enqueue(value);
+    }
+
+    [Benchmark]
+    public void FastQueue_Enqueue()
+    {
+        var q = new FastQueue<int>();
+        foreach (var value in _values)
+            q.Enqueue(value);
+    }
+
+    [Benchmark]
+    public void Queue_Dequeue()
+    {
+        while (_queue.Count > 0)
+            _queue.Dequeue();
+    }
+
+    [Benchmark]
+    public void FastQueue_Dequeue()
+    {
+        while (_fastQueue.Count > 0)
+            _fastQueue.Dequeue();
+    }
+}

--- a/src/Celerity.Benchmarks/Program.cs
+++ b/src/Celerity.Benchmarks/Program.cs
@@ -1,9 +1,10 @@
-﻿using BenchmarkDotNet.Running;
+using System.Reflection;
+using BenchmarkDotNet.Running;
 
 internal class Program
 {
     static void Main(string[] args)
     {
-        BenchmarkRunner.Run<CelerityDictionaryBenchmark>();
+        BenchmarkSwitcher.FromAssembly(Assembly.GetExecutingAssembly()).Run(args);
     }
 }

--- a/src/Celerity.Tests/Collections/FastQueueTests.cs
+++ b/src/Celerity.Tests/Collections/FastQueueTests.cs
@@ -1,0 +1,49 @@
+using Celerity.Collections;
+
+namespace Celerity.Tests.Collections;
+
+public class FastQueueTests
+{
+    [Fact]
+    public void EnqueueDequeue_ShouldReturnItemsInOrder()
+    {
+        var queue = new FastQueue<int>(2);
+        queue.Enqueue(1);
+        queue.Enqueue(2);
+
+        Assert.Equal(1, queue.Dequeue());
+        Assert.Equal(2, queue.Dequeue());
+    }
+
+    [Fact]
+    public void Peek_ShouldReturnFirstItemWithoutRemoving()
+    {
+        var queue = new FastQueue<int>();
+        queue.Enqueue(5);
+        queue.Enqueue(6);
+
+        Assert.Equal(5, queue.Peek());
+        Assert.Equal(5, queue.Dequeue());
+    }
+
+    [Fact]
+    public void Dequeue_ShouldThrow_WhenQueueIsEmpty()
+    {
+        var queue = new FastQueue<int>();
+        Assert.Throws<InvalidOperationException>(() => queue.Dequeue());
+    }
+
+    [Fact]
+    public void Queue_ShouldResize_WhenCapacityExceeded()
+    {
+        var queue = new FastQueue<int>(2);
+        queue.Enqueue(1);
+        queue.Enqueue(2);
+        queue.Enqueue(3); // triggers resize
+
+        Assert.Equal(3, queue.Count);
+        Assert.Equal(1, queue.Dequeue());
+        Assert.Equal(2, queue.Dequeue());
+        Assert.Equal(3, queue.Dequeue());
+    }
+}

--- a/src/Celerity/Collections/FastQueue.cs
+++ b/src/Celerity/Collections/FastQueue.cs
@@ -1,0 +1,98 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace Celerity.Collections;
+
+/// <summary>
+/// Provides a high performance queue based on a circular array.
+/// </summary>
+/// <typeparam name="T">Type of the elements stored in the queue.</typeparam>
+public class FastQueue<T>
+{
+    private const int DEFAULT_CAPACITY = 4;
+
+    private T?[] _items;
+    private int _head;
+    private int _tail;
+    private int _count;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FastQueue{T}"/> class
+    /// with an optional initial capacity.
+    /// </summary>
+    /// <param name="capacity">The initial capacity of the queue.</param>
+    public FastQueue(int capacity = DEFAULT_CAPACITY)
+    {
+        int size = FastUtils.NextPowerOfTwo(capacity);
+        _items = new T?[size];
+        _head = 0;
+        _tail = 0;
+        _count = 0;
+    }
+
+    /// <summary>
+    /// Gets the number of elements contained in the queue.
+    /// </summary>
+    public int Count => _count;
+
+    /// <summary>
+    /// Adds an item to the end of the queue.
+    /// </summary>
+    /// <param name="item">The item to add.</param>
+    public void Enqueue(T item)
+    {
+        if (_count >= _items.Length)
+        {
+            Resize();
+        }
+
+        _items[_tail] = item;
+        _tail = (_tail + 1) & (_items.Length - 1);
+        _count++;
+    }
+
+    /// <summary>
+    /// Removes and returns the item at the beginning of the queue.
+    /// </summary>
+    /// <returns>The item removed from the queue.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when the queue is empty.</exception>
+    public T Dequeue()
+    {
+        if (_count == 0)
+            throw new InvalidOperationException("Queue is empty.");
+
+        T? item = _items[_head];
+        _items[_head] = default;
+        _head = (_head + 1) & (_items.Length - 1);
+        _count--;
+        return item!;
+    }
+
+    /// <summary>
+    /// Returns the item at the beginning of the queue without removing it.
+    /// </summary>
+    /// <returns>The item at the beginning of the queue.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when the queue is empty.</exception>
+    [MaybeNull]
+    public T Peek()
+    {
+        if (_count == 0)
+            throw new InvalidOperationException("Queue is empty.");
+
+        return _items[_head]!;
+    }
+
+    private void Resize()
+    {
+        int newSize = _items.Length * 2;
+        T?[] newItems = new T?[newSize];
+
+        for (int i = 0; i < _count; i++)
+        {
+            newItems[i] = _items[(_head + i) & (_items.Length - 1)];
+        }
+
+        _items = newItems;
+        _head = 0;
+        _tail = _count;
+    }
+}


### PR DESCRIPTION
## Summary
- benchmark FastQueue against built-in Queue
- run all benchmarks by default
- document benchmark results in README

## Testing
- `dotnet test --no-build -c Release src/Celerity.sln` *(fails: `dotnet` not found)*