### PR TITLE
Add safe casting utilities

### DIFF
--- a/src/Celerity.Tests/Utils/SafeCastTests.cs
+++ b/src/Celerity.Tests/Utils/SafeCastTests.cs
@@ -1,0 +1,75 @@
+namespace Celerity.Tests.Utils;
+
+public class SafeCastTests
+{
+    [Theory]
+    [InlineData(0L)]
+    [InlineData(1L)]
+    [InlineData(int.MaxValue)]
+    [InlineData(int.MinValue)]
+    public void SafeLongToInt_ReturnsValue_WhenWithinRange(long value)
+    {
+        int result = FastUtils.SafeLongToInt(value);
+        Assert.Equal((int)value, result);
+    }
+
+    [Theory]
+    [InlineData((long)int.MaxValue + 1)]
+    [InlineData((long)int.MinValue - 1)]
+    public void SafeLongToInt_Throws_WhenOutOfRange(long value)
+    {
+        Assert.Throws<OverflowException>(() => FastUtils.SafeLongToInt(value));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(short.MaxValue)]
+    [InlineData(short.MinValue)]
+    public void SafeIntToShort_ReturnsValue_WhenWithinRange(int value)
+    {
+        short result = FastUtils.SafeIntToShort(value);
+        Assert.Equal((short)value, result);
+    }
+
+    [Theory]
+    [InlineData((int)short.MaxValue + 1)]
+    [InlineData((int)short.MinValue - 1)]
+    public void SafeIntToShort_Throws_WhenOutOfRange(int value)
+    {
+        Assert.Throws<OverflowException>(() => FastUtils.SafeIntToShort(value));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(255)]
+    public void SafeIntToByte_ReturnsValue_WhenWithinRange(int value)
+    {
+        byte result = FastUtils.SafeIntToByte(value);
+        Assert.Equal((byte)value, result);
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(256)]
+    public void SafeIntToByte_Throws_WhenOutOfRange(int value)
+    {
+        Assert.Throws<OverflowException>(() => FastUtils.SafeIntToByte(value));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(char.MaxValue)]
+    public void SafeIntToChar_ReturnsValue_WhenWithinRange(int value)
+    {
+        char result = FastUtils.SafeIntToChar(value);
+        Assert.Equal((char)value, result);
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(char.MaxValue + 1)]
+    public void SafeIntToChar_Throws_WhenOutOfRange(int value)
+    {
+        Assert.Throws<OverflowException>(() => FastUtils.SafeIntToChar(value));
+    }
+}

--- a/src/Celerity/FastUtils.cs
+++ b/src/Celerity/FastUtils.cs
@@ -27,4 +27,64 @@ public static class FastUtils
         n |= n >> 16;
         return n + 1;
     }
+
+    /// <summary>
+    /// Safely casts a <see cref="long"/> to <see cref="int"/>. Throws an
+    /// <see cref="OverflowException"/> if the value cannot fit into an
+    /// <see cref="int"/>.
+    /// </summary>
+    /// <param name="value">The <see cref="long"/> value to cast.</param>
+    /// <returns>The value cast to <see cref="int"/> if within range.</returns>
+    public static int SafeLongToInt(long value)
+    {
+        if (value > int.MaxValue || value < int.MinValue)
+            throw new OverflowException($"{value} does not fit into an Int32.");
+
+        return (int)value;
+    }
+
+    /// <summary>
+    /// Safely casts an <see cref="int"/> to <see cref="short"/>. Throws an
+    /// <see cref="OverflowException"/> if the value cannot fit into a
+    /// <see cref="short"/>.
+    /// </summary>
+    /// <param name="value">The <see cref="int"/> value to cast.</param>
+    /// <returns>The value cast to <see cref="short"/> if within range.</returns>
+    public static short SafeIntToShort(int value)
+    {
+        if (value > short.MaxValue || value < short.MinValue)
+            throw new OverflowException($"{value} does not fit into an Int16.");
+
+        return (short)value;
+    }
+
+    /// <summary>
+    /// Safely casts an <see cref="int"/> to <see cref="byte"/>. Throws an
+    /// <see cref="OverflowException"/> if the value is outside the range
+    /// of <see cref="byte"/> (0-255).
+    /// </summary>
+    /// <param name="value">The value to cast.</param>
+    /// <returns>The cast value.</returns>
+    public static byte SafeIntToByte(int value)
+    {
+        if (value > byte.MaxValue || value < byte.MinValue)
+            throw new OverflowException($"{value} does not fit into a Byte.");
+
+        return (byte)value;
+    }
+
+    /// <summary>
+    /// Safely casts an <see cref="int"/> to <see cref="char"/>. Throws an
+    /// <see cref="OverflowException"/> if the value cannot fit into a
+    /// <see cref="char"/>.
+    /// </summary>
+    /// <param name="value">The value to cast.</param>
+    /// <returns>The cast value.</returns>
+    public static char SafeIntToChar(int value)
+    {
+        if (value > char.MaxValue || value < char.MinValue)
+            throw new OverflowException($"{value} does not fit into a Char.");
+
+        return (char)value;
+    }
 }


### PR DESCRIPTION
## Summary
- extend FastUtils with safe cast helpers similar to Java fastutil `SafeMath`
- add tests covering the new utility methods

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*