### PR TITLE
Fix IntDictionary constructor

### DIFF
--- a/src/Celerity/Collections/IntDictionary.cs
+++ b/src/Celerity/Collections/IntDictionary.cs
@@ -17,10 +17,8 @@ public class IntDictionary<TValue> : IntDictionary<TValue, Int32WangNaiveHasher>
     /// </param>
     public IntDictionary(int capacity = DEFAULT_CAPACITY,
         float loadFactor = DEFAULT_LOAD_FACTOR)
-        : base()
-    {
-
-    }
+        : base(capacity, loadFactor)
+    { }
 }
 
 public class IntDictionary<TValue, THasher> where THasher : struct, IHashProvider<int>


### PR DESCRIPTION
## Summary
- call the generic dictionary constructor with capacity and load factor

## Testing
- `dotnet test` *(fails: `dotnet` not found)*