### PR TITLE
Document how versioning is determined (MinVer + git tags)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -123,12 +123,22 @@ dotnet pack --configuration Release
 ### Benchmarks (Celerity.Benchmarks)
 - BenchmarkDotNet: Performance benchmarking
 
+## Versioning (critical — read before touching any `.csproj`)
+
+**Version numbers are determined solely by git tags.** The library uses [MinVer](https://github.com/adamralph/minver) which reads the nearest `v`-prefixed tag (e.g. `v1.0.1`) from git history and sets the NuGet package version automatically at build time.
+
+**Rules for coding agents:**
+- **NEVER** add `<Version>`, `<PackageVersion>`, or `<AssemblyVersion>` to any `.csproj` file
+- **NEVER** hardcode a version string anywhere in the source tree
+- The `<MinVerTagPrefix>v</MinVerTagPrefix>` and `<MinVerDefaultPreReleaseIdentifiers>beta</MinVerDefaultPreReleaseIdentifiers>` settings in `Celerity.csproj` are the only version-related MSBuild properties — do not change them
+- Pre-release builds (commits after a tag) automatically get versions like `1.0.2-beta.1` — this is correct behavior, not a bug
+- To check the current version: `git tag -l 'v*' --sort=-v:refname | head -1`
+- To see what MinVer computes: `dotnet build /p:MinVerVerbosity=diagnostic`
+
 ## Release Process
 
 Releases are automated via GitHub Actions workflow (`.github/workflows/release.yml`):
-1. Triggered via workflow_dispatch
-2. Builds the solution
-3. Creates NuGet packages
-4. Publishes to NuGet.org
-
-Version numbers are determined by git tags using MinVer with prefix `v` (e.g., `v1.0.0`).
+1. Update `CHANGELOG.md` in a PR and merge to `main`
+2. Tag the merge commit: `git tag -a v1.2.0 -m "Release 1.2.0"` then `git push origin v1.2.0`
+3. Trigger the Release workflow via `workflow_dispatch` in the GitHub Actions UI
+4. The workflow builds, packs, and publishes to NuGet.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,9 +65,48 @@ dotnet run -c Release
 
 If a change is motivated by performance, include before/after numbers in the PR description. Numbers without `-c Release` are not useful — BenchmarkDotNet will refuse to run in Debug and the README benchmarks are all Release.
 
-## Releases
+## Versioning
 
-Releases are cut by a maintainer via the `Release` workflow (`.github/workflows/release.yml`, triggered manually). Version numbers come from git tags via MinVer (`v0.2.0`, `v0.3.0-beta.1`, etc.). The `CHANGELOG.md` file is updated as part of the release PR, not after the fact.
+Celerity uses [MinVer](https://github.com/adamralph/minver) to derive NuGet package versions exclusively from **git tags**. There is no `<Version>` or `<PackageVersion>` property in any `.csproj` file — the single source of truth is the `v`-prefixed annotated tag on the commit that represents a release.
+
+### How it works
+
+1. MinVer walks the git history from `HEAD` looking for the nearest tag matching `v{major}.{minor}.{patch}`.
+2. If `HEAD` **is** the tagged commit, the package version is exactly `{major}.{minor}.{patch}` (e.g. tag `v1.0.1` → version `1.0.1`).
+3. If `HEAD` is **ahead** of the latest tag, MinVer appends a pre-release suffix (e.g. `1.0.2-beta.1`). The default pre-release identifier is `beta`, configured via `<MinVerDefaultPreReleaseIdentifiers>` in `Celerity.csproj`.
+4. The tag prefix `v` is configured via `<MinVerTagPrefix>v</MinVerTagPrefix>` in `Celerity.csproj`.
+
+To check what version MinVer computes locally, run:
+
+```bash
+cd src
+dotnet build /p:MinVerVerbosity=diagnostic 2>&1 | grep MinVer
+```
+
+To see the current released version:
+
+```bash
+git tag -l 'v*' --sort=-v:refname | head -1
+```
+
+### Important for coding agents
+
+- **Never** add `<Version>`, `<PackageVersion>`, or `<AssemblyVersion>` to any `.csproj`. MinVer owns versioning.
+- Pre-release builds (any commit after a tag) produce versions like `1.0.2-beta.1`. This is expected and correct.
+- When preparing a release, update `CHANGELOG.md` first, then tag the merge commit.
+
+### Cutting a release
+
+```bash
+# 1. Merge the release PR (which updates CHANGELOG.md)
+# 2. Tag the merge commit on main
+git tag -a v1.2.0 -m "Release 1.2.0"
+git push origin v1.2.0
+
+# 3. Trigger the Release workflow via GitHub Actions UI (workflow_dispatch)
+```
+
+The `Release` workflow (`.github/workflows/release.yml`) builds, packs, and publishes to NuGet.org.
 
 ## Scope
 


### PR DESCRIPTION
## Summary

- Replace the brief 'Releases' section in CONTRIBUTING.md with a detailed 'Versioning' section explaining how MinVer derives versions from git tags, how to cut a release, and explicit rules for coding agents
- Add a matching 'Versioning' section to `.github/copilot-instructions.md` with clear do/don't rules for agents (never set Version in csproj, etc.)

## Test plan
- [ ] Review that CONTRIBUTING.md versioning section is accurate
- [ ] Review that copilot-instructions.md rules are clear for coding agents
- [ ] Verify no version properties were added to any csproj