### PR TITLE
feat(hashing): add DefaultHasher<T> and XML docs on all hasher types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to Celerity are documented here. This project follows [Keep 
 
 ### Added
 
+- `DefaultHasher<T>` in `Celerity.Hashing` — a general-purpose `IHashProvider<T>` that delegates to `EqualityComparer<T>.Default.GetHashCode()`. Use it when no specialized hasher exists for a type (e.g. `Guid`, custom structs, or reference types). It is a struct, so the JIT devirtualizes the outer call on the probe path; the inner `EqualityComparer<T>` dispatch is unavoidable but acceptable for non-hot-path types.
+- XML doc comments added to `IHashProvider<T>`, `Int32WangNaiveHasher`, `Int64Murmur3Hasher`, and `StringFnV1AHasher`. All public hasher types now carry full XML documentation.
+- `DefaultHasherTests` — verifies BCL contract equivalence for int, string, and Guid keys; determinism across calls and struct instances; and integration tests confirming `DefaultHasher<T>` satisfies the hasher constraints on `CeleritySet<T,THasher>`, `IntSet<THasher>`, and `CelerityDictionary<TKey,TValue,THasher>`.
 - `Add(TKey, TValue)` on `CelerityDictionary` and `IntDictionary` — inserts a key/value pair and throws `ArgumentException` if the key already exists, matching BCL `Dictionary<,>` semantics.
 - `TryAdd(TKey, TValue)` on `CelerityDictionary` and `IntDictionary` — inserts without overwriting; returns `true` on success, `false` if the key already exists.  Both methods correctly handle the zero/default-key out-of-band slot.
 - `TryGetValue(TKey, out TValue?)` on `CelerityDictionary` and `IntDictionary`, following BCL semantics.

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -213,9 +213,9 @@ Both constructors now throw `ArgumentOutOfRangeException` for `capacity < 0`, `l
 - **#10** — Add `Keys` / `Values` / `GetEnumerator()` (0.3.0). Next item to tackle.
 - **#11** — Add `Add` / `TryAdd` with duplicate-throwing semantics (0.3.0). Status: `fixed in 0.3.0`.
 - **#12** — `Int32Murmur3Hasher`, `Int64WangHasher`, `GuidHasher`, `UInt32Hasher`, `UInt64Hasher` (0.4.0).
-- **#13** — `DefaultHasher<T>` fallback to `EqualityComparer<T>.Default.GetHashCode()` (0.4.0).
+- **#13** — `DefaultHasher<T>` fallback to `EqualityComparer<T>.Default.GetHashCode()`. Status: `fixed in 1.1.0`.
 - **#14** — Expanded benchmark suite: uniform vs clustered vs adversarial key distributions (0.4.0).
-- **#15** — `CeleritySet<T, THasher>` and `IntSet` (0.5.0).
+- **#15** — `CeleritySet<T, THasher>` and `IntSet`. Status: `fixed in 1.1.0`.
 - **#16** — `SmallDictionary<TKey, TValue>` optimized for `n <= ~16` (0.5.0).
 - **#17** — `FrozenCelerityDictionary` with perfect hashing for string keys (0.5.0).
 - **#18** — Robin Hood probing experiment (0.6.0).

--- a/src/Celerity.Tests/Hashing/DefaultHasherTests.cs
+++ b/src/Celerity.Tests/Hashing/DefaultHasherTests.cs
@@ -1,0 +1,157 @@
+using Celerity.Collections;
+using Celerity.Hashing;
+
+namespace Celerity.Tests.Hashing;
+
+public class DefaultHasherTests
+{
+    // ── Core contract ──────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(-1)]
+    [InlineData(int.MaxValue)]
+    [InlineData(int.MinValue)]
+    public void Hash_ShouldMatchEqualityComparerDefault_ForInt(int key)
+    {
+        var hasher = new DefaultHasher<int>();
+        Assert.Equal(EqualityComparer<int>.Default.GetHashCode(key), hasher.Hash(key));
+    }
+
+    [Fact]
+    public void Hash_ShouldMatchEqualityComparerDefault_ForString()
+    {
+        var hasher = new DefaultHasher<string>();
+        const string key = "hello world";
+        Assert.Equal(EqualityComparer<string>.Default.GetHashCode(key), hasher.Hash(key));
+    }
+
+    [Fact]
+    public void Hash_ShouldMatchEqualityComparerDefault_ForGuid()
+    {
+        var hasher = new DefaultHasher<Guid>();
+        Guid key = Guid.NewGuid();
+        Assert.Equal(EqualityComparer<Guid>.Default.GetHashCode(key), hasher.Hash(key));
+    }
+
+    [Fact]
+    public void Hash_ShouldMatchEqualityComparerDefault_ForGuidEmpty()
+    {
+        // Guid.Empty is default(Guid); the set/dictionary stores it out-of-band,
+        // but the hasher itself must still produce the correct value.
+        var hasher = new DefaultHasher<Guid>();
+        Assert.Equal(EqualityComparer<Guid>.Default.GetHashCode(Guid.Empty), hasher.Hash(Guid.Empty));
+    }
+
+    // ── Determinism ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Hash_ShouldBeConsistent_WhenCalledMultipleTimes()
+    {
+        var hasher = new DefaultHasher<string>();
+        const string key = "consistency";
+        int h1 = hasher.Hash(key);
+        int h2 = hasher.Hash(key);
+        Assert.Equal(h1, h2);
+    }
+
+    [Fact]
+    public void Hash_ShouldBeConsistent_AcrossInstances()
+    {
+        // Each DefaultHasher<T> is a new struct value — they must agree.
+        var h1 = new DefaultHasher<int>().Hash(99);
+        var h2 = new DefaultHasher<int>().Hash(99);
+        Assert.Equal(h1, h2);
+    }
+
+    // ── Integration: usable as a CeleritySet hasher ────────────────────────────
+
+    [Fact]
+    public void DefaultHasher_CanDriveIntSet_ViaIntSet()
+    {
+        // DefaultHasher<Guid> as a stand-in for an arbitrary type on CeleritySet.
+        // (IntSet uses Int32WangNaiveHasher by default; here we use DefaultHasher
+        //  through the generic IntSet<THasher> overload to verify the constraint.)
+        var set = new IntSet<DefaultHasher<int>>(capacity: 16);
+
+        set.Add(1);
+        set.Add(2);
+        set.Add(0);   // zero key goes out-of-band
+        set.Add(-1);
+
+        Assert.Equal(4, set.Count);
+        Assert.True(set.Contains(0));
+        Assert.True(set.Contains(1));
+        Assert.True(set.Contains(2));
+        Assert.True(set.Contains(-1));
+        Assert.False(set.Contains(42));
+    }
+
+    [Fact]
+    public void DefaultHasher_CanDriveCeleritySet_ForGuidKeys()
+    {
+        // Guid has no specialized hasher in Celerity yet; DefaultHasher fills the gap.
+        var set = new CeleritySet<Guid, DefaultHasher<Guid>>();
+
+        var a = Guid.NewGuid();
+        var b = Guid.NewGuid();
+        var c = Guid.Empty;   // default(Guid) — stored out-of-band
+
+        set.Add(a);
+        set.Add(b);
+        set.Add(c);
+
+        Assert.Equal(3, set.Count);
+        Assert.True(set.Contains(a));
+        Assert.True(set.Contains(b));
+        Assert.True(set.Contains(c));
+        Assert.False(set.Contains(Guid.NewGuid()));
+    }
+
+    [Fact]
+    public void DefaultHasher_CanDriveCeleritySet_ForStringKeys()
+    {
+        var set = new CeleritySet<string, DefaultHasher<string>>();
+
+        set.Add("alpha");
+        set.Add("beta");
+        set.Add("gamma");
+
+        Assert.Equal(3, set.Count);
+        Assert.True(set.Contains("alpha"));
+        Assert.False(set.Contains("delta"));
+    }
+
+    [Fact]
+    public void DefaultHasher_CanDriveCelerityDictionary_ForGuidKeys()
+    {
+        // Demonstrates that DefaultHasher<T> satisfies the dictionary's hasher constraint.
+        var dict = new CelerityDictionary<Guid, string, DefaultHasher<Guid>>();
+
+        var key = Guid.NewGuid();
+        dict[key] = "value";
+
+        Assert.Equal("value", dict[key]);
+        Assert.True(dict.ContainsKey(key));
+    }
+
+    // ── Duplicate / remove round-trip ──────────────────────────────────────────
+
+    [Fact]
+    public void DefaultHasher_SetDuplicateHandling_WorksCorrectly()
+    {
+        var set = new CeleritySet<string, DefaultHasher<string>>();
+
+        Assert.True(set.TryAdd("x"));
+        Assert.False(set.TryAdd("x"));   // duplicate
+        Assert.Equal(1, set.Count);
+
+        Assert.True(set.Remove("x"));
+        Assert.False(set.Contains("x"));
+        Assert.Equal(0, set.Count);
+
+        Assert.True(set.TryAdd("x"));    // re-insert after remove
+        Assert.Equal(1, set.Count);
+    }
+}

--- a/src/Celerity/Hashing/DefaultHasher.cs
+++ b/src/Celerity/Hashing/DefaultHasher.cs
@@ -1,0 +1,29 @@
+using System.Runtime.CompilerServices;
+
+namespace Celerity.Hashing;
+
+/// <summary>
+/// A general-purpose hash provider that delegates to
+/// <see cref="EqualityComparer{T}.Default"/>.<see cref="EqualityComparer{T}.GetHashCode(T)"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Use <see cref="DefaultHasher{T}"/> when no specialized hasher exists for a type, or
+/// when you want the same hash distribution as the BCL's default equality comparer
+/// (e.g. for <see cref="Guid"/>, custom structs, or reference types).
+/// </para>
+/// <para>
+/// Because <see cref="DefaultHasher{T}"/> is a struct, the JIT can still devirtualize
+/// the call to <see cref="Hash"/> on the collection's hot probe path.
+/// The inner call to <see cref="EqualityComparer{T}.Default"/> may itself involve a
+/// virtual dispatch, so specialized hashers (e.g. <see cref="Int32WangNaiveHasher"/>,
+/// <see cref="Int64Murmur3Hasher"/>) will be faster when available.
+/// </para>
+/// </remarks>
+/// <typeparam name="T">The type of key to hash.</typeparam>
+public struct DefaultHasher<T> : IHashProvider<T>
+{
+    /// <inheritdoc/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public int Hash(T key) => EqualityComparer<T>.Default.GetHashCode(key!);
+}

--- a/src/Celerity/Hashing/IHashProvider.cs
+++ b/src/Celerity/Hashing/IHashProvider.cs
@@ -1,6 +1,21 @@
-﻿namespace Celerity.Hashing;
+namespace Celerity.Hashing;
 
+/// <summary>
+/// Provides a hash function for values of type <typeparamref name="T"/>.
+/// </summary>
+/// <remarks>
+/// Implementations must be value types (structs). This is a load-bearing constraint:
+/// the JIT can devirtualize calls made through a generic type parameter constrained to
+/// <c>where THasher : struct, IHashProvider&lt;T&gt;</c>, eliminating virtual dispatch
+/// on the hot probe path.
+/// </remarks>
+/// <typeparam name="T">The type of value to hash.</typeparam>
 public interface IHashProvider<T>
 {
+    /// <summary>
+    /// Computes a hash code for the specified value.
+    /// </summary>
+    /// <param name="key">The value to hash.</param>
+    /// <returns>A 32-bit signed integer hash code.</returns>
     int Hash(T key);
 }

--- a/src/Celerity/Hashing/Int32WangNaiveHasher.cs
+++ b/src/Celerity/Hashing/Int32WangNaiveHasher.cs
@@ -1,10 +1,21 @@
-﻿using System.Runtime.CompilerServices;
+using System.Runtime.CompilerServices;
 
 namespace Celerity.Hashing;
 
+/// <summary>
+/// A fast hash provider for <see cref="int"/> keys using a Wang/Jenkins-style
+/// integer bit-mixer.
+/// </summary>
+/// <remarks>
+/// This is a lightweight finalizer that folds the high bits of the integer into
+/// the low bits (<c>key ^ (key &gt;&gt; 16)</c>). It is extremely fast but has modest
+/// avalanche properties compared to a full Murmur3 finalizer. Prefer it when
+/// key distribution is already reasonably uniform and latency matters more than
+/// collision resistance.
+/// </remarks>
 public struct Int32WangNaiveHasher : IHashProvider<int>
 {
+    /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public int Hash(int key) => key ^ (key >> 16);
-
 }

--- a/src/Celerity/Hashing/Int64Murmur3Hasher.cs
+++ b/src/Celerity/Hashing/Int64Murmur3Hasher.cs
@@ -1,12 +1,23 @@
-﻿using System.Runtime.CompilerServices;
+using System.Runtime.CompilerServices;
 
 namespace Celerity.Hashing;
 
+/// <summary>
+/// A high-quality hash provider for <see cref="long"/> keys using the
+/// Murmur3 64-bit finalizer ("fmix64").
+/// </summary>
+/// <remarks>
+/// This is the same finalizer used in MurmurHash3 for 64-bit keys. It has
+/// excellent avalanche properties — every input bit affects every output bit —
+/// making it a good choice for clustered or adversarial key distributions.
+/// The result is truncated to 32 bits by taking the lower half.
+/// </remarks>
 public struct Int64Murmur3Hasher : IHashProvider<long>
 {
     private const long C1 = unchecked((long)0xff51afd7ed558ccdUL);
     private const long C2 = unchecked((long)0xc4ceb9fe1a85ec53UL);
 
+    /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public int Hash(long key)
     {

--- a/src/Celerity/Hashing/StringFnV1AHasher.cs
+++ b/src/Celerity/Hashing/StringFnV1AHasher.cs
@@ -1,9 +1,19 @@
-﻿using System.Runtime.CompilerServices;
+using System.Runtime.CompilerServices;
 
 namespace Celerity.Hashing;
 
+/// <summary>
+/// A hash provider for <see cref="string"/> keys using the FNV-1a 32-bit algorithm.
+/// </summary>
+/// <remarks>
+/// FNV-1a has good distribution for short strings and is simple to implement.
+/// Note that this implementation hashes only the lower byte of each character,
+/// so strings that differ only in high bytes of non-ASCII characters may collide.
+/// For Unicode-heavy workloads, a full UTF-8 or UTF-16 hash is preferable.
+/// </remarks>
 public struct StringFnV1AHasher : IHashProvider<string>
 {
+    /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public int Hash(string key)
     {
@@ -14,7 +24,7 @@ public struct StringFnV1AHasher : IHashProvider<string>
         uint hash = offsetBasis;
         foreach (char c in key)
         {
-            // Convert char to its lower byte; you may also want to consider 
+            // Convert char to its lower byte; you may also want to consider
             // encoding specifics if you deal with non-ASCII characters.
             hash ^= (byte)(c & 0xFF);
             hash *= fnvPrime;


### PR DESCRIPTION
## Summary

- Adds `DefaultHasher<T>` — a general-purpose `IHashProvider<T>` struct that delegates to `EqualityComparer<T>.Default.GetHashCode()`. Lets callers use `CeleritySet<Guid, DefaultHasher<Guid>>` (or any other type) without writing a custom hasher.
- Adds XML doc comments to `IHashProvider<T>`, `Int32WangNaiveHasher`, `Int64Murmur3Hasher`, and `StringFnV1AHasher` — all public hasher types now have full documentation. Closes the XML doc gap called out in milestone 1.1.0.
- Closes backlog items #13 (`DefaultHasher<T>`) and marks #15 (`CeleritySet`/`IntSet`) as `fixed in 1.1.0`.

## Test plan

- [ ] `DefaultHasherTests` — BCL contract equivalence for `int`, `string`, `Guid`; determinism across calls and struct instances
- [ ] Integration: `DefaultHasher<T>` satisfies hasher constraints on `CeleritySet<T,THasher>`, `IntSet<THasher>`, and `CelerityDictionary<TKey,TValue,THasher>`
- [ ] Duplicate/remove round-trip via `CeleritySet<string, DefaultHasher<string>>`
- [ ] CI (`dotnet build` + `dotnet test` on net8.0) must be green

🤖 Generated with [Claude Code](https://claude.com/claude-code)