### PR TITLE
Promote CS1591 (missing XML doc) from warning to error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Celerity are documented here. This project follows [Keep 
 
 ## [Unreleased]
 
+### Changed
+
+- **CS1591 (missing XML doc comment) is now a build error in `Celerity.csproj`**, not just a warning. Celerity ships its generated `.xml` documentation file with the NuGet package; gating on CS1591 ensures every public type / member retains a doc comment so that file is never silently incomplete. The library was already at 100% public-symbol doc coverage at the time of the change, so no source had to be updated — this is purely a guardrail to prevent regression. Implements the "Bump XML doc coverage; treat missing docs as warning-as-error" item from the milestone 1.1.0 infrastructure roadmap. Scoped to the main library `.csproj` only; the test and benchmark projects are unaffected because they do not set `<GenerateDocumentationFile>true</GenerateDocumentationFile>`.
+
 ### Added
 
 - `IEnumerable<KeyValuePair<TKey, TValue>>` constructor on both `CelerityDictionary<TKey, TValue, THasher>` and `IntDictionary<TValue, THasher>` (and the `IntDictionary<TValue>` convenience subclass). Matches BCL `Dictionary<,>` semantics: throws `ArgumentNullException` on a null source and `ArgumentException` on duplicate keys (including duplicate zero / default keys). When the source implements `ICollection<T>`, its `Count` is used to size the backing storage so the initial fill avoids at least some resize work; non-collection enumerables fall back to the caller-supplied `capacity` parameter. The out-of-band zero-key / default-key slot is populated correctly when the source contains an entry with `default(TKey)`. Completes the last of the milestone 1.1.0 API-parity items on the dictionaries.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -60,7 +60,7 @@ The next release rounds out the `Celerity.Collections` package with missing coll
 - Cross-platform testing (Windows, Linux, macOS). (#28)
 - Improve code coverage. (#29)
 - Improve documentation. (#15)
-- Bump XML doc coverage; treat missing docs as warning-as-error.
+- Bump XML doc coverage; treat missing docs as warning-as-error. Status: `done` — `Celerity.csproj` now promotes CS1591 to error via `<WarningsAsErrors>$(WarningsAsErrors);CS1591</WarningsAsErrors>`. Library was already at 100% public-symbol doc coverage at the time of the change; this is a guardrail for future PRs.
 
 ## Milestone 1.2.0 — Performance & advanced collections
 

--- a/src/Celerity/Celerity.csproj
+++ b/src/Celerity/Celerity.csproj
@@ -8,6 +8,14 @@
 		<Authors>Marius Bughiu</Authors>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
+		<!--
+		  Promote CS1591 (missing XML comment for publicly visible type or member)
+		  from warning to error. Celerity is a public NuGet package; every public
+		  symbol must carry an XML doc comment so the generated .xml shipping in
+		  the package is complete. The library is at 100% public-symbol doc
+		  coverage today and this gate keeps it that way.
+		-->
+		<WarningsAsErrors>$(WarningsAsErrors);CS1591</WarningsAsErrors>
 		<PackageId>Celerity.Collections</PackageId>
 		<PackageIcon>icon.png</PackageIcon>
 		<PackageTags>celerity;collections</PackageTags>


### PR DESCRIPTION
## Summary

Promote `CS1591` (missing XML comment for publicly visible type or member) from **warning** to **error** in `src/Celerity/Celerity.csproj`. Implements the `Bump XML doc coverage; treat missing docs as warning-as-error` infrastructure item from milestone 1.1.0 of `ROADMAP.md`.

Celerity ships its generated `Celerity.xml` documentation file inside the `Celerity.Collections` NuGet package, so every public type and member must carry an XML doc comment. The library is at 100% public-symbol doc coverage today, but nothing prevented a future PR from adding a public symbol without docs and silently shipping an incomplete `.xml` file. This change adds that guard.

## Change

- `src/Celerity/Celerity.csproj` — added `<WarningsAsErrors>$(WarningsAsErrors);CS1591</WarningsAsErrors>` next to `<GenerateDocumentationFile>true</GenerateDocumentationFile>`, with an inline XML comment explaining the intent.
- Scope is limited to the main library project. `Celerity.Tests` and `Celerity.Benchmarks` do not set `<GenerateDocumentationFile>true</GenerateDocumentationFile>`, so the C# compiler does not raise CS1591 for them and the gate has no effect there.
- `CHANGELOG.md` — entry under `[Unreleased] / Changed`.
- `ROADMAP.md` — marked the milestone 1.1.0 infrastructure item as `done` with rationale.

## Test plan

- [x] `dotnet build src/Celerity.sln` — succeeds, 0 errors. (38 unrelated pre-existing `xUnit2013` warnings in test code, not affected by this change.)
- [x] Negative-path probe: temporarily added a public `ProbeUndocumented` class with no doc comment to `src/Celerity/`. Build now produces `error CS1591` (not warning) and `Build FAILED`, confirming the gate fires as expected. Probe was removed before commit.
- [ ] CI runs `dotnet build` + `dotnet test` on this branch and validates the change end-to-end on the same matrix the rest of the project uses. Local `dotnet test` cannot run on this machine: only the .NET 10 runtime is installed and the test host targets `net8.0`.

## Notes for reviewers

- No source files were modified — proves the existing public surface is fully documented.
- The change is intentionally targeted (`WarningsAsErrors` for the single rule) rather than broad (`TreatWarningsAsErrors=true`) to avoid promoting unrelated future warnings to errors.