### PR TITLE
Refresh README and docs for the v1.1.0 surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,16 @@
 
 Celerity is a .NET library that provides specialized high-performance collections optimized for specific use cases. It includes data structures designed for better speed or memory efficiency compared to standard .NET collections. The package supports configurable load factors, multiple built-in hash functions, and allows users to define custom hash functions for fine-tuned performance.
 
+## Collections
+
+- `CelerityDictionary<TKey, TValue, THasher>` — generic dictionary with a struct hasher constraint.
+- `IntDictionary<TValue>` / `IntDictionary<TValue, THasher>` — `int`-keyed specialization. Defaults to `Int32WangNaiveHasher`.
+- `LongDictionary<TValue>` / `LongDictionary<TValue, THasher>` — `long`-keyed specialization. Defaults to `Int64WangHasher`.
+- `CeleritySet<T, THasher>` — generic set counterpart to `CelerityDictionary`.
+- `IntSet` / `IntSet<THasher>` — `int`-keyed set specialization.
+
+All dictionaries implement `IReadOnlyDictionary<TKey, TValue?>` and ship allocation-free struct enumerators, `Keys` / `Values` views, and an `IEnumerable<KeyValuePair<TKey, TValue>>` constructor. All collections handle `default(TKey)` (or zero for `int` / `long` keys, `null` for reference-type keys) out-of-band so it never collides with the empty-slot sentinel.
+
 ## Benchmarks
 
 #### CelerityDictionary
@@ -28,18 +38,22 @@ Celerity is a .NET library that provides specialized high-performance collection
 
 You can bring your own custom hash provider by implementing the `IHashProvider<T>` interface.
 
-```
+```csharp
 public interface IHashProvider<T>
 {
     int Hash(T key);
 }
 ```
 
+Hashers must be **structs** when used with Celerity collections (`where THasher : struct, IHashProvider<T>`) so the JIT can devirtualize and inline `Hash()`. The package ships built-in hashers for `int`, `long`, `uint`, `ulong`, `Guid`, and `string`, plus a `DefaultHasher<T>` fallback that delegates to `EqualityComparer<T>.Default.GetHashCode()`. See [`docs/api/hashing.md`](docs/api/hashing.md) for the full list.
+
 ## API overview
 
-Both `CelerityDictionary<TKey, TValue, THasher>` and `IntDictionary<TValue>` expose a compact, allocation-conscious API that mirrors the parts of `Dictionary<TKey, TValue>` most users actually reach for: indexer get/set, `ContainsKey`, `TryGetValue`, `Add`, `TryAdd`, `Remove`, `Clear`, and `Count`.
+The dictionaries (`CelerityDictionary`, `IntDictionary`, `LongDictionary`) expose a compact, allocation-conscious API that mirrors the parts of `Dictionary<TKey, TValue>` most users actually reach for: indexer get/set, `ContainsKey`, `TryGetValue`, `Add`, `TryAdd`, `Remove` (both the `bool Remove(key)` and `bool Remove(key, out TValue?)` overloads), `Clear`, `Count`, `Keys`, `Values`, and `GetEnumerator()`. They implement `IReadOnlyDictionary<TKey, TValue?>` and accept an `IEnumerable<KeyValuePair<TKey, TValue>>` source at construction.
 
-`IntDictionary` handles the key value `0` and `CelerityDictionary` handles `default(TKey)` (including `null` for reference-type keys) — both are stored out-of-band so they don't collide with the "empty slot" sentinel used during probing.
+The sets (`CeleritySet`, `IntSet`) expose `Add`, `TryAdd`, `Contains`, `Remove`, `Clear`, `Count`, and a struct enumerator.
+
+The zero / `default(TKey)` key (or element, for sets) is stored out-of-band so it never collides with the empty-slot sentinel used during probing. This includes `null` for reference-type keys.
 
 For full API details — constructors, method signatures, parameters, exceptions, and usage examples — see the **[API reference docs](docs/README.md)**.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,8 +4,8 @@ This folder contains reference documentation for the Celerity high-performance c
 
 ## Contents
 
-- [Collections](api/collections.md) — `CelerityDictionary<TKey, TValue, THasher>` and `IntDictionary<TValue>`.
-- [Hashing](api/hashing.md) — `IHashProvider<T>` interface and built-in hashers.
+- [Collections](api/collections.md) — `CelerityDictionary`, `IntDictionary`, `LongDictionary`, `CeleritySet`, `IntSet`.
+- [Hashing](api/hashing.md) — `IHashProvider<T>` interface and built-in hashers (`Int32WangNaiveHasher`, `Int32Murmur3Hasher`, `Int64WangHasher`, `Int64Murmur3Hasher`, `UInt32Hasher`, `UInt64Hasher`, `GuidHasher`, `StringFnV1AHasher`, `DefaultHasher<T>`).
 - [Utilities](api/utilities.md) — `FastUtils` helper methods.
 
 ## Quick links

--- a/docs/api/collections.md
+++ b/docs/api/collections.md
@@ -4,10 +4,11 @@ All collection types live in the `Celerity.Collections` namespace.
 
 ## CelerityDictionary&lt;TKey, TValue, THasher&gt;
 
-A high-performance generic dictionary parameterized on a custom hash provider. Uses open addressing with linear probing and power-of-two sizing for fast index computation.
+A high-performance generic dictionary parameterized on a custom hash provider. Uses open addressing with linear probing and power-of-two sizing for fast index computation. Implements `IReadOnlyDictionary<TKey, TValue?>`.
 
 ```csharp
 public class CelerityDictionary<TKey, TValue, THasher>
+    : IReadOnlyDictionary<TKey, TValue?>
     where THasher : struct, IHashProvider<TKey>
 ```
 
@@ -21,14 +22,23 @@ The `where THasher : struct, IHashProvider<TKey>` constraint lets the JIT devirt
 public CelerityDictionary(
     int capacity = 16,
     float loadFactor = 0.75f)
+
+public CelerityDictionary(
+    IEnumerable<KeyValuePair<TKey, TValue>> source,
+    int capacity = 16,
+    float loadFactor = 0.75f)
 ```
 
 Creates a new dictionary. `capacity` is rounded up to the next power of two. `loadFactor` controls the fill ratio before the internal arrays are resized.
+
+The `IEnumerable<KeyValuePair<TKey, TValue>>` overload copies entries from `source`. When `source` implements `ICollection<T>`, its `Count` is used to size the backing storage so initial fills avoid resize work; for non-collection enumerables, the caller-supplied `capacity` parameter is used. The out-of-band `default(TKey)` slot is populated when the source contains an entry with `default(TKey)`.
 
 **Throws:**
 
 - `ArgumentOutOfRangeException` if `capacity < 0`.
 - `ArgumentOutOfRangeException` if `loadFactor <= 0` or `loadFactor >= 1`.
+- `ArgumentNullException` if `source` is `null` (enumerable overload).
+- `ArgumentException` if `source` contains duplicate keys (enumerable overload).
 
 ### Properties
 
@@ -84,9 +94,12 @@ Inserts `key`/`value` if the key is not already present. Returns `true` on succe
 
 ```csharp
 public bool Remove(TKey key)
+public bool Remove(TKey key, out TValue? value)
 ```
 
 Removes the entry for `key`. Returns `true` if the key was found and removed, `false` otherwise. After removal, adjacent entries are rehashed to maintain probe-chain correctness.
+
+The capture overload sets `value` to the value that was associated with the key immediately before removal, or to `default(TValue)` if the key was not found. The out-of-band default-key slot is surfaced through this path identically to the regular probe table.
 
 #### Clear
 
@@ -103,6 +116,10 @@ public Enumerator GetEnumerator()
 ```
 
 Returns a struct enumerator that yields `KeyValuePair<TKey, TValue?>`. The out-of-band default-key entry is yielded first if present. Mutating the dictionary during enumeration throws `InvalidOperationException` from the next `MoveNext` / `Reset` call, matching BCL `Dictionary<,>` semantics. Iteration order is unspecified and may change between versions.
+
+### IReadOnlyDictionary&lt;TKey, TValue?&gt;
+
+`CelerityDictionary` implements `IReadOnlyDictionary<TKey, TValue?>` via thin explicit interface forwarders on top of the existing struct `KeyCollection` / `ValueCollection` / `Enumerator` types. The zero-allocation `foreach` fast path is preserved; the interface path boxes the enumerator exactly once per `GetEnumerator()` call, matching BCL `Dictionary<,>` behaviour. The out-of-band default-key entry is surfaced through every interface member.
 
 ### Default-key handling
 
@@ -158,10 +175,11 @@ Same semantics and validation as `CelerityDictionary`.
 
 ## IntDictionary&lt;TValue, THasher&gt;
 
-A high-performance dictionary keyed by `int`, parameterized on a custom hash provider. This is a separate implementation from `CelerityDictionary` that avoids the boxing/equality-comparer overhead of generic key types by working directly with `int` keys and using `==` for comparisons.
+A high-performance dictionary keyed by `int`, parameterized on a custom hash provider. This is a separate implementation from `CelerityDictionary` that avoids the boxing/equality-comparer overhead of generic key types by working directly with `int` keys and using `==` for comparisons. Implements `IReadOnlyDictionary<int, TValue?>`.
 
 ```csharp
 public class IntDictionary<TValue, THasher>
+    : IReadOnlyDictionary<int, TValue?>
     where THasher : struct, IHashProvider<int>
 ```
 
@@ -171,9 +189,14 @@ public class IntDictionary<TValue, THasher>
 public IntDictionary(
     int capacity = 16,
     float loadFactor = 0.75f)
+
+public IntDictionary(
+    IEnumerable<KeyValuePair<int, TValue>> source,
+    int capacity = 16,
+    float loadFactor = 0.75f)
 ```
 
-**Throws** the same exceptions as `CelerityDictionary`.
+**Throws** the same exceptions as `CelerityDictionary`. The enumerable overload follows the same `source`-sizing and duplicate-key semantics described above.
 
 ### Properties
 
@@ -193,8 +216,11 @@ The method signatures and semantics match `CelerityDictionary`:
 - `void Add(int key, TValue value)` — throws `ArgumentException` on duplicate.
 - `bool TryAdd(int key, TValue value)`
 - `bool Remove(int key)`
+- `bool Remove(int key, out TValue? value)` — capture overload; `value` is the previous value or `default` if the key was absent.
 - `void Clear()`
 - `Enumerator GetEnumerator()` — struct enumerator yielding `KeyValuePair<int, TValue?>`. The out-of-band zero-key entry is yielded first if present. Mutating the dictionary during enumeration throws `InvalidOperationException` from the next `MoveNext` / `Reset` call, matching BCL `Dictionary<,>` semantics. Iteration order is unspecified and may change between versions.
+
+`IntDictionary<TValue, THasher>` also implements `IReadOnlyDictionary<int, TValue?>` with the same explicit-interface forwarding pattern as `CelerityDictionary`.
 
 ### Zero-key handling
 
@@ -219,4 +245,180 @@ foreach (var kvp in ids)
 
 foreach (int key in ids.Keys) { /* ... */ }
 foreach (var value in ids.Values) { /* ... */ }
+```
+
+---
+
+## LongDictionary&lt;TValue&gt;
+
+A convenience subclass of `LongDictionary<TValue, Int64WangHasher>` for the common case of 64-bit integer-keyed dictionaries.
+
+```csharp
+public class LongDictionary<TValue>
+    : LongDictionary<TValue, Int64WangHasher>
+```
+
+### Constructors
+
+```csharp
+public LongDictionary(
+    int capacity = 16,
+    float loadFactor = 0.75f)
+
+public LongDictionary(
+    IEnumerable<KeyValuePair<long, TValue>> source,
+    int capacity = 16,
+    float loadFactor = 0.75f)
+```
+
+Same semantics and validation as `IntDictionary`.
+
+---
+
+## LongDictionary&lt;TValue, THasher&gt;
+
+A high-performance dictionary keyed by `long`, parameterized on a custom hash provider. Mirrors `IntDictionary` but for 64-bit keys. Defaults to `Int64WangHasher` when used through the convenience subclass. Implements `IReadOnlyDictionary<long, TValue?>`.
+
+```csharp
+public class LongDictionary<TValue, THasher>
+    : IReadOnlyDictionary<long, TValue?>
+    where THasher : struct, IHashProvider<long>
+```
+
+### API
+
+The public surface and semantics match `IntDictionary`:
+
+- `this[long key]`
+- `bool ContainsKey(long key)`
+- `bool TryGetValue(long key, out TValue? value)`
+- `void Add(long key, TValue value)` — throws `ArgumentException` on duplicate.
+- `bool TryAdd(long key, TValue value)`
+- `bool Remove(long key)`
+- `bool Remove(long key, out TValue? value)`
+- `void Clear()`
+- `Enumerator GetEnumerator()` — struct enumerator yielding `KeyValuePair<long, TValue?>`.
+- `KeyCollection Keys`, `ValueCollection Values` — allocation-free struct views.
+
+### Zero-key handling
+
+The key `0L` collides with the `EMPTY_KEY` sentinel and is stored out-of-band the same way `IntDictionary` handles the key `0`. Two keys that share the lower 32 bits but differ in the upper 32 bits are kept distinct (the probe path does not truncate).
+
+### Usage example
+
+```csharp
+using Celerity.Collections;
+
+var map = new LongDictionary<string>();
+map[0L] = "zero is fine";
+map[long.MaxValue] = "edge";
+map[(long)int.MaxValue + 1L] = "no truncation";
+
+Console.WriteLine(map.Count); // 3
+```
+
+---
+
+## CeleritySet&lt;T, THasher&gt;
+
+A high-performance generic set parameterized on a custom hash provider. Set counterpart to `CelerityDictionary`. Implements `IEnumerable<T>`.
+
+```csharp
+public class CeleritySet<T, THasher> : IEnumerable<T>
+    where THasher : struct, IHashProvider<T>
+```
+
+### Constructors
+
+```csharp
+public CeleritySet(
+    int capacity = 16,
+    float loadFactor = 0.75f)
+```
+
+Throws the same `ArgumentOutOfRangeException`s as the dictionaries.
+
+### Methods
+
+- `void Add(T item)` — throws `ArgumentException` on duplicate.
+- `bool TryAdd(T item)` — `true` on success, `false` if already present.
+- `bool Contains(T item)`
+- `bool Remove(T item)`
+- `void Clear()`
+- `int Count { get; }`
+- `Enumerator GetEnumerator()` — struct enumerator. The out-of-band `default(T)` entry (zero for primitives, `Guid.Empty`, `null` for reference types) is yielded first when present.
+
+### Default-element handling
+
+`default(T)` is stored out-of-band via a `_hasDefaultValue` flag and never collides with the empty-slot sentinel. Mutating the set during enumeration throws `InvalidOperationException` on the next `MoveNext` / `Reset`, matching BCL `HashSet<T>`.
+
+### Usage example
+
+```csharp
+using Celerity.Collections;
+using Celerity.Hashing;
+
+var ids = new CeleritySet<Guid, GuidHasher>();
+ids.Add(Guid.NewGuid());
+ids.Add(Guid.Empty); // default-element slot
+Console.WriteLine(ids.Contains(Guid.Empty)); // True
+
+foreach (var id in ids) { /* ... */ }
+```
+
+---
+
+## IntSet
+
+A convenience subclass of `IntSet<Int32WangNaiveHasher>` for the common case of integer sets.
+
+```csharp
+public class IntSet : IntSet<Int32WangNaiveHasher>
+```
+
+### Constructors
+
+```csharp
+public IntSet(
+    int capacity = 16,
+    float loadFactor = 0.75f)
+```
+
+---
+
+## IntSet&lt;THasher&gt;
+
+A high-performance set of `int` values, parameterized on a custom hash provider. Implements `IEnumerable<int>`.
+
+```csharp
+public class IntSet<THasher> : IEnumerable<int>
+    where THasher : struct, IHashProvider<int>
+```
+
+### Methods
+
+- `void Add(int item)` — throws `ArgumentException` on duplicate.
+- `bool TryAdd(int item)`
+- `bool Contains(int item)`
+- `bool Remove(int item)`
+- `void Clear()`
+- `int Count { get; }`
+- `Enumerator GetEnumerator()` — struct enumerator. The out-of-band zero entry is yielded first when present.
+
+### Zero-element handling
+
+The element `0` collides with the `EMPTY_SLOT` sentinel and is stored out-of-band, same pattern as `IntDictionary`'s zero-key handling.
+
+### Usage example
+
+```csharp
+using Celerity.Collections;
+
+var seen = new IntSet();
+seen.Add(0);   // zero is fine
+seen.Add(42);
+Console.WriteLine(seen.Contains(0));  // True
+Console.WriteLine(seen.Count);        // 2
+
+foreach (int n in seen) { /* ... */ }
 ```

--- a/docs/api/hashing.md
+++ b/docs/api/hashing.md
@@ -71,3 +71,69 @@ FNV-1a 32-bit hash for string keys. Iterates over each `char` in the string, XOR
 **Parameters:** offset basis = `2166136261`, prime = `16777619`.
 
 **Note:** This hasher uses only the lower byte of each character (`c & 0xFF`), which means it does not fully distinguish characters that differ only in their upper byte. For most ASCII-dominated workloads this is fine; for keys with significant non-ASCII content, consider writing a custom hasher that processes both bytes.
+
+### Int32Murmur3Hasher
+
+```csharp
+public struct Int32Murmur3Hasher : IHashProvider<int>
+```
+
+The MurmurHash3 32-bit finalizer (`fmix32`) applied to `int` keys. Better avalanche than `Int32WangNaiveHasher` — prefer when key distribution is clustered or adversarial.
+
+**Note:** maps `0 → 0` (a fixed point of `fmix32`), so the dictionaries' out-of-band zero-key slot is engaged just as it is with the simpler hashers.
+
+### Int64WangHasher
+
+```csharp
+public struct Int64WangHasher : IHashProvider<long>
+```
+
+Thomas Wang's 64-bit integer hash for `long` keys. Faster than `Int64Murmur3Hasher` while still providing better avalanche than a simple XOR-fold. Bijective on `ulong`, so the only source of collisions is truncation to 32 bits when the result is returned. Default hasher for `LongDictionary<TValue>`.
+
+### UInt32Hasher
+
+```csharp
+public struct UInt32Hasher : IHashProvider<uint>
+```
+
+Wang/Jenkins-style bit-mixer for `uint` keys. Counterpart to `Int32WangNaiveHasher` for unsigned 32-bit integers.
+
+### UInt64Hasher
+
+```csharp
+public struct UInt64Hasher : IHashProvider<ulong>
+```
+
+MurmurHash3 64-bit finalizer (`fmix64`) for `ulong` keys. Counterpart to `Int64Murmur3Hasher` for unsigned 64-bit integers.
+
+### GuidHasher
+
+```csharp
+public struct GuidHasher : IHashProvider<Guid>
+```
+
+Reinterprets the 128-bit `Guid` as two 64-bit halves (via `Unsafe.As<Guid, ulong>`, no stack buffer), runs `fmix64` on each, and XORs the mixed halves. Prefer over `DefaultHasher<Guid>` on hot paths — it is fully inlineable and avoids the `EqualityComparer<Guid>.Default` virtual dispatch.
+
+**Note:** maps `Guid.Empty → 0`, so dictionaries / sets keyed on `Guid` engage the out-of-band default-key slot for `Guid.Empty`.
+
+### DefaultHasher&lt;T&gt;
+
+```csharp
+public struct DefaultHasher<T> : IHashProvider<T>
+```
+
+A general-purpose `IHashProvider<T>` that delegates to `EqualityComparer<T>.Default.GetHashCode()`. Use it when no specialized hasher exists for a key type — custom structs, reference types without a built-in hasher, or to bridge an existing `IEqualityComparer<T>`-based design into the Celerity API.
+
+It is a struct, so the JIT devirtualizes the outer call on the probe path. The inner `EqualityComparer<T>` dispatch is unavoidable but acceptable for non-hot-path types — if `Hash` is on the hot path for a known key type, write a struct-specific hasher instead.
+
+### Choosing a hasher
+
+| Key type | Default | Alternative |
+|---|---|---|
+| `int` | `Int32WangNaiveHasher` (used by `IntDictionary` / `IntSet`) | `Int32Murmur3Hasher` for clustered or adversarial keys |
+| `long` | `Int64WangHasher` (used by `LongDictionary`) | `Int64Murmur3Hasher` for clustered or adversarial keys |
+| `uint` | `UInt32Hasher` | — |
+| `ulong` | `UInt64Hasher` | — |
+| `Guid` | `GuidHasher` | `DefaultHasher<Guid>` (slower but BCL-equivalent) |
+| `string` | `StringFnV1AHasher` | `DefaultHasher<string>` (uses the BCL string hasher) |
+| anything else | `DefaultHasher<T>` | a struct hasher you write |


### PR DESCRIPTION
## Summary

- Adds Collections list and new-hasher pointer to README so the NuGet-package README matches what shipped between v1.0.1 and [Unreleased]
- Documents `LongDictionary`, `CeleritySet`, `IntSet`, the `IEnumerable<KeyValuePair>` constructor, the `Remove(key, out value)` capture overload, and the `IReadOnlyDictionary<TKey, TValue?>` interface implementation in `docs/api/collections.md`
- Documents the six new hashers (`Int32Murmur3Hasher`, `Int64WangHasher`, `UInt32Hasher`, `UInt64Hasher`, `GuidHasher`, `DefaultHasher<T>`) in `docs/api/hashing.md`, plus a "choosing a hasher" table
- Updates the `docs/README.md` index

This is the first of three PRs prepping for the v1.1.0 release. Must merge before the v1.1.0 tag because `PackageReadmeFile` ships `README.md` inside the .nupkg.

## Test plan

- [x] `dotnet build src/` clean (0 errors)
- [ ] CI green
- [ ] Sanity check on README rendering on GitHub