### PR TITLE
Trigger release workflow on tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,9 @@
 name: Release
 
-on: workflow_dispatch
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
 
 env:
   NuGetDirectory: ${{ github.workspace}}/nuget
@@ -47,7 +50,7 @@ jobs:
         if-no-files-found: error
         retention-days: 7
         path: ${{ env.NuGetDirectory }}/*.nupkg
-  
+
   deploy:
     runs-on: ubuntu-latest
     needs: [ build ]
@@ -64,5 +67,52 @@ jobs:
         run: |
           foreach($file in (Get-ChildItem "${{ env.NuGetDirectory }}" -Recurse -Include *.nupkg)) {
               dotnet nuget push $file --api-key "${{ secrets.NUGET_APIKEY }}" --source https://api.nuget.org/v3/index.json --skip-duplicate
-          }      
-  
+          }
+
+  github-release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    needs: [ deploy ]
+    if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: nuget
+          path: ${{ env.NuGetDirectory }}
+
+      - name: Extract release notes from CHANGELOG.md
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag="${GITHUB_REF_NAME}"
+          version="${tag#v}"
+          # Extract the section under "## [<version>]" up to (but not including)
+          # the next "## [" heading. Empty output means the CHANGELOG was not
+          # updated for this version — fail loudly so the maintainer notices.
+          awk -v ver="$version" '
+            $0 ~ "^## \\[" ver "\\]" { capture = 1; next }
+            capture && /^## \[/ { exit }
+            capture { print }
+          ' CHANGELOG.md > release-notes.md
+          if [ ! -s release-notes.md ]; then
+            echo "::error::No CHANGELOG.md section found for [$version]. Move the [Unreleased] block to [$version] and re-tag." >&2
+            exit 1
+          fi
+          echo "--- Release notes for $tag ---"
+          cat release-notes.md
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          gh release create "$GITHUB_REF_NAME" \
+            --title "$GITHUB_REF_NAME" \
+            --notes-file release-notes.md \
+            ${{ env.NuGetDirectory }}/*.nupkg

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,16 +97,19 @@ git tag -l 'v*' --sort=-v:refname | head -1
 
 ### Cutting a release
 
+Releases are automated. Pushing a `v`-prefixed tag fires `.github/workflows/release.yml`, which builds, packs, publishes to NuGet.org, and creates a matching GitHub Release with notes extracted from `CHANGELOG.md`.
+
 ```bash
-# 1. Merge the release PR (which updates CHANGELOG.md)
-# 2. Tag the merge commit on main
+# 1. Move the CHANGELOG [Unreleased] block to [X.Y.Z] (with today's date if you
+#    want one — the workflow does not require a date), commit, and merge to main.
+# 2. Tag the merge commit and push the tag.
 git tag -a v1.2.0 -m "Release 1.2.0"
 git push origin v1.2.0
-
-# 3. Trigger the Release workflow via GitHub Actions UI (workflow_dispatch)
 ```
 
-The `Release` workflow (`.github/workflows/release.yml`) builds, packs, and publishes to NuGet.org.
+The workflow extracts the `## [X.Y.Z]` section of `CHANGELOG.md` and uses it as the GitHub Release body. If no matching section exists for the tag's version, the workflow fails loudly — the fix is to update `CHANGELOG.md` and re-tag.
+
+`workflow_dispatch` is still wired up as a manual fallback for ad-hoc re-publishes (e.g. if a NuGet push fails partway through), but the normal flow is tag-push.
 
 ## Scope
 


### PR DESCRIPTION
## Summary

- `release.yml` now fires on `push: tags: ['v*']` (with `workflow_dispatch` kept as a manual fallback)
- New `github-release` job extracts the `## [<version>]` section of `CHANGELOG.md` and calls `gh release create` with the `.nupkg` attached. Fails loudly if no matching CHANGELOG section exists, so a forgotten `[Unreleased]` → `[X.Y.Z]` bump can't ship a blank release.
- `CONTRIBUTING.md` "Cutting a release" updated to describe the tag-push flow.

## Why

Until now the release workflow was manual-only. Combined with merges accumulating in `[Unreleased]`, a full release's worth of work has been sitting un-tagged. After this lands, the v1.1.0 release is just `git tag -a v1.1.0 && git push --tags`.

`NUGET_APIKEY` is unchanged. The new GH-release step uses the default `GITHUB_TOKEN` with explicit `permissions: contents: write`. No new secrets needed.

## Test plan

- [ ] Manual `workflow_dispatch` on this branch confirms `dotnet pack` still works (run via GitHub UI after merge to main, or push a throwaway `v1.1.0-rc1` tag)
- [ ] After PR #58 merges, push `v1.1.0` and confirm: NuGet publish succeeds, GitHub Release is created with notes from CHANGELOG, .nupkg attached