### PR TITLE
Throw ArgumentNullException on StringFnV1AHasher.Hash(null)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Celerity are documented here. This project follows [Keep 
 
 ## [Unreleased]
 
+### Fixed
+
+- `StringFnV1AHasher.Hash(null)` now throws `ArgumentNullException` (parameter name `"key"`) instead of `NullReferenceException`. Public APIs should signal a null argument as an explicit contract violation, not as an unchecked dereference. The Celerity dictionaries store the out-of-band `null` / `default(TKey)` key entry without ever calling the hasher, so the surface area of this change is limited to direct `StringFnV1AHasher` usage and to consumers that plug the hasher into custom `IHashProvider<string>` callers that do not handle the null-key slot themselves. The XML doc comment on `Hash` now declares the exception, and `StringFnV1AHasherTests.Hash_NullString_*` is updated to assert `ArgumentNullException` rather than pinning the previous wart. Closes #71.
+
 ### Added
 
 - `README.md` — new "Choosing a collection" section: a decision table mapping common workloads (`int`-keyed, `long`-keyed, `Guid` / `string` / other-keyed dictionaries, the two set shapes) onto the right Celerity type, plus a short note on picking a hasher and an honest "where Celerity is not the right answer today" list (concurrent access, mutable `IDictionary<,>` consumers, `FrozenDictionary`-style build-once lookups). Sits between the Quick start and Benchmarks sections so a reader who has scanned the API surface can pick the right type without spelunking `docs/api/`. Implements the "Document when to use which collection" item from issue #15.

--- a/src/Celerity.Tests/Hashing/StringFnV1AHasherTests.cs
+++ b/src/Celerity.Tests/Hashing/StringFnV1AHasherTests.cs
@@ -66,13 +66,18 @@ public class StringFnV1AHasherTests
     }
 
     /// <summary>
-    /// Demonstrates what happens if you pass null into the current implementation.
-    /// The current code will throw NullReferenceException (or potentially an NRE).
-    /// If you'd prefer an explicit ArgumentNullException, modify the struct.
+    /// Hashing a null reference must throw <see cref="ArgumentNullException"/>
+    /// (with the parameter name "key"), not the NullReferenceException the
+    /// implicit dereference would otherwise produce. Celerity dictionaries
+    /// route the out-of-band null/default-key entry around the hasher, so the
+    /// check only ever fires for direct hasher usage — but when it fires, the
+    /// thrown exception must reflect a contract violation, not an unchecked
+    /// dereference. Closes issue #71.
     /// </summary>
     [Fact]
-    public void Hash_NullString_ThrowsNullReferenceException()
+    public void Hash_NullString_ThrowsArgumentNullException()
     {
-        Assert.Throws<NullReferenceException>(() => _hasher.Hash(null));
+        ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() => _hasher.Hash(null!));
+        Assert.Equal("key", ex.ParamName);
     }
 }

--- a/src/Celerity/Hashing/StringFnV1AHasher.cs
+++ b/src/Celerity/Hashing/StringFnV1AHasher.cs
@@ -13,10 +13,22 @@ namespace Celerity.Hashing;
 /// </remarks>
 public struct StringFnV1AHasher : IHashProvider<string>
 {
-    /// <inheritdoc/>
+    /// <summary>
+    /// Computes the FNV-1a 32-bit hash of the specified string.
+    /// </summary>
+    /// <param name="key">The string to hash. Must not be <c>null</c>.</param>
+    /// <returns>The signed 32-bit FNV-1a hash of <paramref name="key"/>.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="key"/> is <c>null</c>. Celerity dictionaries store the
+    /// out-of-band <c>null</c>-key entry without calling the hasher, so this
+    /// check only surfaces when the hasher is used directly or plugged into a
+    /// consumer that does not handle <c>null</c> keys out-of-band.
+    /// </exception>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public int Hash(string key)
     {
+        ArgumentNullException.ThrowIfNull(key);
+
         // The FNV-1a 32-bit parameters
         const uint fnvPrime = 16777619;
         const uint offsetBasis = 2166136261;


### PR DESCRIPTION
## Summary

Closes #71. Replaces the `NullReferenceException` that `StringFnV1AHasher.Hash(null)` currently throws with an explicit `ArgumentNullException` (parameter name `"key"`), and updates the test that previously pinned the NRE behaviour.

`NullReferenceException` from a public API is a code-quality wart per .NET framework design guidelines — it conflates a programmer error (unchecked dereference) with what is really a contract violation. The previous test even openly noted the wart: *"If you'd prefer an explicit ArgumentNullException, modify the struct."* This PR makes that change.

### Surface area

The Celerity dictionaries route the out-of-band `null` / `default(TKey)` key entry around the hasher and never call `Hash(null)`, so existing dictionary callers see no behaviour change. The new `ArgumentNullException` only surfaces when:

- callers use `StringFnV1AHasher` directly (e.g. as a building block in their own collection or a hash-quality test harness), or
- callers plug `StringFnV1AHasher` into a custom `IHashProvider<string>` consumer that does not handle the null-key slot itself.

In both cases the new exception is the correct one — and the regression test pins it down.

### Files

- `src/Celerity/Hashing/StringFnV1AHasher.cs` — `ArgumentNullException.ThrowIfNull(key)` at the top of `Hash`, plus a full XML doc on the method declaring the exception.
- `src/Celerity.Tests/Hashing/StringFnV1AHasherTests.cs` — `Hash_NullString_ThrowsNullReferenceException` is renamed to `Hash_NullString_ThrowsArgumentNullException` and asserts both the exception type and `ParamName == "key"`.
- `CHANGELOG.md` — `[Unreleased]` `Fixed` entry.

## Test plan

- [x] `dotnet build` clean (0 errors; 55 pre-existing xUnit2013 warnings in unrelated test files)
- [ ] CI runs `StringFnV1AHasherTests` on Linux / Windows / macOS — local runtime is .NET 10 only and the projects target net8.0, so the test execution gate is CI
- [x] Coverage in `StringFnV1AHasherTests.Hash_NullString_ThrowsArgumentNullException`:
  - `Hash(null!)` throws `ArgumentNullException`
  - The thrown exception's `ParamName` is `"key"`
- [x] No change to existing dictionary code paths — the out-of-band null/default-key handling already short-circuits the hasher call.