### PR TITLE
Replace stale "issue #23" ref in TryAddProbeCountTests docstring

### DIFF
--- a/src/Celerity.Tests/Collections/TryAddProbeCountTests.cs
+++ b/src/Celerity.Tests/Collections/TryAddProbeCountTests.cs
@@ -4,7 +4,8 @@ using Celerity.Hashing;
 namespace Celerity.Tests.Collections;
 
 /// <summary>
-/// Regression tests for issue #23. <see cref="IntDictionary{TValue, THasher}.TryAdd"/>,
+/// Regression tests for the single-probe <c>TryAdd</c> rewrite (PR #53).
+/// <see cref="IntDictionary{TValue, THasher}.TryAdd"/>,
 /// <see cref="CelerityDictionary{TKey, TValue, THasher}.TryAdd"/>,
 /// <see cref="IntSet{THasher}.TryAdd"/>, and
 /// <see cref="CeleritySet{T, THasher}.TryAdd"/> historically walked the probe chain


### PR DESCRIPTION
## What

Updates the class docstring on `TryAddProbeCountTests` to point at PR #53 instead of "issue #23". One-line comment edit; no test or production behaviour change.

## Why

The docstring previously read "Regression tests for issue #23". That number was an internal `ISSUES.md` reference, used before the backlog was migrated to GitHub Issues (commit `0f84d86`). On GitHub today, [#23](https://github.com/marius-bughiu/Celerity/issues/23) is "Add SIMD optimizations" — a different and currently-open piece of work. A reader who follows the cross-reference lands on a totally unrelated topic.

The single-probe `TryAdd` rewrite that this test class actually pins landed in [PR #53](https://github.com/marius-bughiu/Celerity/pull/53), and that PR's description is the right place to send a curious reader.

## Test plan

- [x] `dotnet build` — clean (0 errors, pre-existing 50 warnings unchanged).
- [ ] `dotnet test` — not strictly needed; this is a comment-only change. Will run if CI requests.