### PR TITLE
ci: branded landing page + custom benchmark dashboard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,3 +113,27 @@ jobs:
           summary-always: true
           gh-pages-branch: gh-pages
           benchmark-data-dir-path: dev/bench
+
+      - name: Sync custom dashboard to gh-pages
+        # Runs only on main push (same gate as the action's auto-push).
+        # Copies web/index.html + web/dev/bench/index.html into gh-pages,
+        # leaving the action-managed data.js untouched. Idempotent.
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        working-directory: ${{ github.workspace }}
+        run: |
+          set -euo pipefail
+          git fetch origin gh-pages
+          git worktree add /tmp/gh-pages gh-pages
+          cp web/index.html /tmp/gh-pages/index.html
+          mkdir -p /tmp/gh-pages/dev/bench
+          cp web/dev/bench/index.html /tmp/gh-pages/dev/bench/index.html
+          cd /tmp/gh-pages
+          if git diff --quiet && git diff --cached --quiet; then
+            echo "No dashboard changes to sync"
+            exit 0
+          fi
+          git -c user.name="github-actions" -c user.email="github-actions@github.com" \
+            add index.html dev/bench/index.html
+          git -c user.name="github-actions" -c user.email="github-actions@github.com" \
+            commit -m "Sync custom dashboard from ${GITHUB_SHA:0:7}"
+          git push origin gh-pages

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Celerity
-[![NuGet version (Celerity.Collections)](https://img.shields.io/nuget/v/Celerity.Collections.svg?style=flat-square)](https://www.nuget.org/packages/Celerity.Collections/) [![NuGet version (Celerity.Collections)](https://img.shields.io/nuget/vpre/Celerity.Collections.svg?style=flat-square)](https://www.nuget.org/packages/Celerity.Collections/)
+[![NuGet version (Celerity.Collections)](https://img.shields.io/nuget/v/Celerity.Collections.svg?style=flat-square)](https://www.nuget.org/packages/Celerity.Collections/) [![NuGet version (Celerity.Collections)](https://img.shields.io/nuget/vpre/Celerity.Collections.svg?style=flat-square)](https://www.nuget.org/packages/Celerity.Collections/) [![Live benchmarks](https://img.shields.io/badge/benchmarks-live-0d6e6e?style=flat-square)](https://marius-bughiu.github.io/Celerity/dev/bench/)
 
 Celerity is a .NET library that provides specialized high-performance collections optimized for specific use cases. It includes data structures designed for better speed or memory efficiency compared to standard .NET collections. The package supports configurable load factors, multiple built-in hash functions, and allows users to define custom hash functions for fine-tuned performance.
 
@@ -134,6 +134,8 @@ A few cases where Celerity is **not** the right answer today:
 - **Build-once / read-many lookup tables for string keys.** Today the BCL `FrozenDictionary<,>` will outperform `CelerityDictionary` on lookups; the Celerity equivalent (`FrozenCelerityDictionary`) is planned for 1.2.0 ([#62](https://github.com/marius-bughiu/Celerity/issues/62)).
 
 ## Benchmarks
+
+> **Live results** — the full suite (all 5 collections, 60 measurements) runs in CI on every `main` push and publishes to the [live dashboard](https://marius-bughiu.github.io/Celerity/dev/bench/) with historical trends and PR comparisons. The static numbers below are a snapshot for quick reference.
 
 #### CelerityDictionary
 

--- a/web/dev/bench/.gitignore
+++ b/web/dev/bench/.gitignore
@@ -1,0 +1,4 @@
+# data.js is owned by the github-action-benchmark action on the gh-pages branch.
+# We keep a local copy here for previewing the dashboard against real data,
+# but the file itself never belongs in the main branch.
+data.js

--- a/web/dev/bench/index.html
+++ b/web/dev/bench/index.html
@@ -1,0 +1,590 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Celerity Benchmarks — live performance vs the .NET BCL</title>
+  <meta name="description" content="Continuous performance tracking for Celerity, a .NET library of high-performance collections. Live results from CI vs the .NET BCL.">
+  <style>
+    :root {
+      --fg: #1a1d1f;
+      --fg-muted: #5a6166;
+      --fg-faint: #8a9296;
+      --bg: #ffffff;
+      --bg-alt: #f7f8f8;
+      --border: #e5e8ea;
+      --border-strong: #cdd2d5;
+      --accent: #0d6e6e;
+      --accent-fg: #ffffff;
+      --bcl: #8a9296;
+      --celerity: #0d6e6e;
+      --win: #0d6e6e;
+      --loss: #b54545;
+      --font: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Helvetica Neue", Helvetica, Arial, sans-serif;
+      --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+    }
+    * { box-sizing: border-box; }
+    html, body { margin: 0; padding: 0; }
+    body {
+      font-family: var(--font);
+      color: var(--fg);
+      background: var(--bg);
+      line-height: 1.55;
+      font-size: 16px;
+      -webkit-font-smoothing: antialiased;
+    }
+    a { color: var(--accent); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    .wrap { max-width: 1100px; margin: 0 auto; padding: 0 24px; }
+
+    /* Header */
+    header.site {
+      border-bottom: 1px solid var(--border);
+      padding: 18px 0;
+      background: var(--bg);
+    }
+    header.site .wrap { display: flex; align-items: center; gap: 24px; }
+    header.site .brand {
+      font-weight: 600;
+      font-size: 17px;
+      color: var(--fg);
+      letter-spacing: -0.01em;
+    }
+    header.site .brand .dot { color: var(--accent); }
+    header.site nav { display: flex; gap: 18px; margin-left: auto; font-size: 14px; }
+    header.site nav a { color: var(--fg-muted); }
+    header.site nav a:hover { color: var(--fg); text-decoration: none; }
+    @media (max-width: 640px) {
+      header.site nav { gap: 12px; font-size: 13px; }
+      header.site nav a:nth-child(3) { display: none; }
+    }
+
+    /* Hero */
+    section.hero { padding: 48px 0 24px; }
+    .hero h1 {
+      font-size: 32px;
+      line-height: 1.2;
+      margin: 0 0 10px;
+      letter-spacing: -0.02em;
+      font-weight: 600;
+    }
+    .hero p.lead {
+      font-size: 16px;
+      color: var(--fg-muted);
+      max-width: 680px;
+      margin: 0 0 24px;
+    }
+    @media (max-width: 640px) {
+      section.hero { padding: 32px 0 16px; }
+      .hero h1 { font-size: 26px; }
+    }
+
+    /* Stat cards */
+    .stats {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 12px;
+      margin: 0 0 8px;
+    }
+    @media (max-width: 720px) { .stats { grid-template-columns: 1fr; } }
+    .stat {
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 16px 18px;
+      background: var(--bg);
+    }
+    .stat .label {
+      font-size: 12px;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: var(--fg-muted);
+      margin-bottom: 6px;
+    }
+    .stat .value {
+      font-size: 28px;
+      font-weight: 600;
+      letter-spacing: -0.01em;
+      color: var(--fg);
+    }
+    .stat .value .unit { font-size: 16px; color: var(--fg-muted); font-weight: 500; margin-left: 4px; }
+    .stat .sub { font-size: 13px; color: var(--fg-faint); margin-top: 4px; }
+
+    /* Section heads */
+    .section-head {
+      margin: 48px 0 12px;
+      display: flex;
+      align-items: baseline;
+      justify-content: space-between;
+      gap: 16px;
+    }
+    .section-head h2 {
+      margin: 0;
+      font-size: 14px;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--fg-muted);
+      font-weight: 600;
+    }
+    .section-head .meta { font-size: 13px; color: var(--fg-faint); }
+
+    /* About */
+    .about {
+      border: 1px solid var(--border);
+      background: var(--bg-alt);
+      border-radius: 8px;
+      padding: 16px 18px;
+      font-size: 14px;
+      color: var(--fg-muted);
+      line-height: 1.6;
+    }
+    .about strong { color: var(--fg); font-weight: 600; }
+    .about code { font-family: var(--mono); font-size: 13px; background: var(--bg); padding: 1px 5px; border-radius: 3px; border: 1px solid var(--border); }
+
+    /* Collection panel */
+    .collection {
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      margin-bottom: 16px;
+      background: var(--bg);
+      overflow: hidden;
+    }
+    .collection-head {
+      display: flex;
+      align-items: baseline;
+      justify-content: space-between;
+      gap: 12px;
+      padding: 16px 20px;
+      border-bottom: 1px solid var(--border);
+      background: var(--bg-alt);
+    }
+    .collection-head h3 {
+      margin: 0;
+      font-size: 16px;
+      font-weight: 600;
+      letter-spacing: -0.01em;
+    }
+    .collection-head .vs {
+      font-size: 13px;
+      color: var(--fg-muted);
+    }
+    .collection-head .vs code {
+      font-family: var(--mono);
+      font-size: 12px;
+      color: var(--fg);
+    }
+    .charts {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 0;
+    }
+    @media (max-width: 980px) { .charts { grid-template-columns: 1fr; } }
+    .chart-cell {
+      padding: 16px 20px 20px;
+      border-right: 1px solid var(--border);
+    }
+    .chart-cell:last-child { border-right: none; }
+    @media (max-width: 980px) {
+      .chart-cell { border-right: none; border-bottom: 1px solid var(--border); }
+      .chart-cell:last-child { border-bottom: none; }
+    }
+    .chart-cell .op {
+      font-size: 12px;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      color: var(--fg-muted);
+      font-weight: 600;
+      margin-bottom: 4px;
+    }
+    .chart-cell .ratio {
+      font-size: 22px;
+      font-weight: 600;
+      letter-spacing: -0.01em;
+      margin-bottom: 2px;
+    }
+    .chart-cell .ratio.win { color: var(--win); }
+    .chart-cell .ratio.loss { color: var(--loss); }
+    .chart-cell .ratio.tie { color: var(--fg-muted); }
+    .chart-cell .detail { font-size: 12px; color: var(--fg-muted); margin-bottom: 10px; }
+    .chart-cell canvas { width: 100% !important; height: 140px !important; display: block; }
+    .chart-cell .empty {
+      height: 140px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: var(--fg-faint);
+      font-size: 13px;
+      border: 1px dashed var(--border);
+      border-radius: 4px;
+    }
+
+    /* Legend */
+    .legend {
+      display: flex;
+      gap: 16px;
+      font-size: 12px;
+      color: var(--fg-muted);
+      margin: 8px 0 0;
+    }
+    .legend .swatch {
+      display: inline-block;
+      width: 10px;
+      height: 10px;
+      border-radius: 2px;
+      margin-right: 6px;
+      vertical-align: middle;
+    }
+
+    /* Footer */
+    footer.site {
+      margin: 64px 0 32px;
+      padding-top: 24px;
+      border-top: 1px solid var(--border);
+      font-size: 13px;
+      color: var(--fg-faint);
+    }
+    footer.site .wrap { display: flex; justify-content: space-between; flex-wrap: wrap; gap: 12px; }
+    footer.site code { font-family: var(--mono); font-size: 12px; }
+
+    /* Empty / error states */
+    .notice {
+      border: 1px dashed var(--border-strong);
+      border-radius: 8px;
+      padding: 32px 24px;
+      text-align: center;
+      color: var(--fg-muted);
+      background: var(--bg-alt);
+    }
+  </style>
+</head>
+<body>
+
+<header class="site">
+  <div class="wrap">
+    <a href="../../" class="brand">Celerity<span class="dot">.</span></a>
+    <nav>
+      <a href="../../">Home</a>
+      <a href="https://github.com/marius-bughiu/Celerity">GitHub</a>
+      <a href="https://www.nuget.org/packages/Celerity.Collections/">NuGet</a>
+    </nav>
+  </div>
+</header>
+
+<main class="wrap">
+  <section class="hero">
+    <h1>Benchmarks</h1>
+    <p class="lead">Live BenchmarkDotNet results for every collection in Celerity, measured on each <code>main</code> commit and compared against its .NET BCL counterpart. Hosted CI runners are noisy &mdash; treat trends as the signal, individual points as noise.</p>
+
+    <div class="stats" id="stats">
+      <div class="stat"><div class="label">Lookup</div><div class="value">&mdash;</div><div class="sub">vs Dictionary / HashSet</div></div>
+      <div class="stat"><div class="label">Insert</div><div class="value">&mdash;</div><div class="sub">vs Dictionary / HashSet</div></div>
+      <div class="stat"><div class="label">Remove</div><div class="value">&mdash;</div><div class="sub">vs Dictionary / HashSet</div></div>
+    </div>
+
+    <div class="legend">
+      <span><span class="swatch" style="background:var(--bcl)"></span>.NET BCL baseline</span>
+      <span><span class="swatch" style="background:var(--celerity)"></span>Celerity</span>
+    </div>
+  </section>
+
+  <div class="section-head">
+    <h2>Methodology</h2>
+  </div>
+  <div class="about">
+    <strong>What you're looking at.</strong> Each chart plots one operation (e.g. <em>Lookup</em>) on one collection, with the BCL baseline and Celerity's implementation over time. Y-axis is nanoseconds per invocation (lower is better). Numbers come from <a href="https://benchmarkdotnet.org/">BenchmarkDotNet</a> running in GitHub Actions on <code>ubuntu-latest</code> with <code>WarmupCount=3</code>, <code>IterationCount=5</code>. The full source is in <a href="https://github.com/marius-bughiu/Celerity/tree/main/src/Celerity.Benchmarks"><code>src/Celerity.Benchmarks</code></a>. Local Release runs use the default BenchmarkDotNet job and produce more stable numbers &mdash; this dashboard exists to catch regressions and surface trends, not as a precision instrument.
+  </div>
+
+  <div class="section-head">
+    <h2>Per-collection results</h2>
+    <span class="meta" id="run-count"></span>
+  </div>
+  <div id="collections"></div>
+
+  <div id="empty-state" class="notice" style="display:none">
+    No benchmark data yet. The first measurement lands here after the next push to <code>main</code>.
+  </div>
+</main>
+
+<footer class="site">
+  <div class="wrap">
+    <span id="footer-build">&mdash;</span>
+    <span>
+      <a href="data.js">Raw data (data.js)</a>
+      &middot;
+      <a href="https://github.com/marius-bughiu/Celerity">Source</a>
+    </span>
+  </div>
+</footer>
+
+<script src="data.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.7/dist/chart.umd.min.js"></script>
+<script>
+(function () {
+  'use strict';
+
+  // Layout: ordered list of collections + the BCL counterpart label for the "vs" subtitle.
+  // The class prefix in benchmark names is "{prefix}Benchmark", and methods are
+  // named "{TypeName}_{Op}". BCL types: Dictionary, HashSet. Celerity types: the rest.
+  var COLLECTIONS = [
+    { key: 'IntDictionary',       title: 'IntDictionary<int>',                       vs: 'Dictionary<int, int>',  ops: ['Insert', 'Lookup', 'Remove'] },
+    { key: 'LongDictionary',      title: 'LongDictionary<int>',                      vs: 'Dictionary<long, int>', ops: ['Insert', 'Lookup', 'Remove'] },
+    { key: 'CelerityDictionary',  title: 'CelerityDictionary<int, int, ...>',        vs: 'Dictionary<int, int>',  ops: ['Insert', 'Lookup', 'Remove'] },
+    { key: 'IntSet',              title: 'IntSet',                                   vs: 'HashSet<int>',          ops: ['Add', 'Contains', 'Remove'] },
+    { key: 'CeleritySet',         title: 'CeleritySet<int, ...>',                    vs: 'HashSet<int>',          ops: ['Add', 'Contains', 'Remove'] }
+  ];
+
+  var BCL_TYPES = new Set(['Dictionary', 'HashSet']);
+  var ITEM_COUNT_FOR_HEADLINE = 100000;
+
+  var data = window.BENCHMARK_DATA;
+  if (!data || !data.entries || !data.entries['Celerity Benchmarks'] || data.entries['Celerity Benchmarks'].length === 0) {
+    document.getElementById('collections').style.display = 'none';
+    document.getElementById('empty-state').style.display = 'block';
+    return;
+  }
+
+  var runs = data.entries['Celerity Benchmarks'];
+  var latest = runs[runs.length - 1];
+
+  // ---- Parse benchmark name into structured fields ----
+  function parseName(name) {
+    // "CelerityDictionaryBenchmark.CelerityDictionary_Lookup(ItemCount: 1000)"
+    var m = name.match(/^(\w+)Benchmark\.(\w+?)_(\w+)\(ItemCount:\s*(\d+)\)$/);
+    if (!m) return null;
+    var collection = m[1];
+    var typeName = m[2];
+    var op = m[3];
+    var itemCount = parseInt(m[4], 10);
+    var isBcl = BCL_TYPES.has(typeName);
+    return { collection: collection, typeName: typeName, op: op, itemCount: itemCount, isBcl: isBcl };
+  }
+
+  // ---- Build a quick-lookup index of latest values per (collection, op, itemCount, kind) ----
+  function indexBenches(benches) {
+    var idx = {};
+    benches.forEach(function (b) {
+      var p = parseName(b.name);
+      if (!p) return;
+      var key = p.collection + '|' + p.op + '|' + p.itemCount;
+      if (!idx[key]) idx[key] = {};
+      idx[key][p.isBcl ? 'bcl' : 'celerity'] = b.value;
+    });
+    return idx;
+  }
+  var latestIdx = indexBenches(latest.benches);
+
+  // ---- Headline stats: best speedup per logical op category, at 100k items ----
+  // Categories: Lookup (Lookup + Contains), Insert (Insert + Add), Remove.
+  function headlineFor(opAliases) {
+    var best = null;
+    Object.keys(latestIdx).forEach(function (key) {
+      var parts = key.split('|');
+      var op = parts[1];
+      var n = parseInt(parts[2], 10);
+      if (opAliases.indexOf(op) === -1) return;
+      if (n !== ITEM_COUNT_FOR_HEADLINE) return;
+      var pair = latestIdx[key];
+      if (pair.bcl == null || pair.celerity == null) return;
+      var ratio = pair.bcl / pair.celerity;
+      if (best == null || ratio > best.ratio) {
+        best = { ratio: ratio, collection: parts[0], op: op };
+      }
+    });
+    return best;
+  }
+
+  function fmtSpeedup(stat) {
+    if (!stat) return { value: '&mdash;', sub: 'no data' };
+    var r = stat.ratio;
+    var label, cls;
+    if (r >= 1.05) { label = r.toFixed(2) + '<span class="unit">&times; faster</span>'; cls = 'win'; }
+    else if (r <= 0.95) { label = (1 / r).toFixed(2) + '<span class="unit">&times; slower</span>'; cls = 'loss'; }
+    else { label = '~ parity'; cls = 'tie'; }
+    return { value: label, sub: 'best result: ' + stat.collection + ' &middot; ' + stat.op + ' &middot; ' + (ITEM_COUNT_FOR_HEADLINE / 1000) + 'k items', cls: cls };
+  }
+
+  var statDefs = [
+    { selector: 0, aliases: ['Lookup', 'Contains'] },
+    { selector: 1, aliases: ['Insert', 'Add'] },
+    { selector: 2, aliases: ['Remove'] }
+  ];
+  var statEls = document.querySelectorAll('#stats .stat');
+  statDefs.forEach(function (d) {
+    var s = fmtSpeedup(headlineFor(d.aliases));
+    var el = statEls[d.selector];
+    el.querySelector('.value').innerHTML = s.value;
+    el.querySelector('.sub').innerHTML = s.sub;
+  });
+
+  // ---- Charts per collection ----
+  function ratioFor(collection, op, itemCount) {
+    var key = collection + '|' + op + '|' + itemCount;
+    var pair = latestIdx[key];
+    if (!pair || pair.bcl == null || pair.celerity == null) return null;
+    return pair.bcl / pair.celerity;
+  }
+
+  // For each (collection, op), collect the time series across all runs.
+  function seriesFor(collection, op, itemCount) {
+    var labels = [];
+    var bcl = [];
+    var celerity = [];
+    runs.forEach(function (run) {
+      var pair = {};
+      run.benches.forEach(function (b) {
+        var p = parseName(b.name);
+        if (!p) return;
+        if (p.collection !== collection || p.op !== op || p.itemCount !== itemCount) return;
+        pair[p.isBcl ? 'bcl' : 'celerity'] = b.value;
+      });
+      labels.push({
+        date: new Date(run.date),
+        sha: run.commit.id,
+        message: run.commit.message.split('\n')[0]
+      });
+      bcl.push(pair.bcl == null ? null : pair.bcl);
+      celerity.push(pair.celerity == null ? null : pair.celerity);
+    });
+    return { labels: labels, bcl: bcl, celerity: celerity };
+  }
+
+  function fmtNs(v) {
+    if (v == null) return '&mdash;';
+    if (v >= 1e6) return (v / 1e6).toFixed(2) + ' ms';
+    if (v >= 1e3) return (v / 1e3).toFixed(2) + ' &mu;s';
+    return Math.round(v) + ' ns';
+  }
+
+  function chartOptions() {
+    return {
+      responsive: true,
+      maintainAspectRatio: false,
+      animation: false,
+      plugins: {
+        legend: { display: false },
+        tooltip: {
+          backgroundColor: '#1a1d1f',
+          padding: 10,
+          titleFont: { size: 12, weight: 'normal' },
+          bodyFont: { size: 12 },
+          callbacks: {
+            title: function (items) {
+              var i = items[0].dataIndex;
+              var lbl = items[0].chart.options.__labels[i];
+              return lbl.date.toISOString().slice(0, 10) + ' &middot; ' + lbl.sha.slice(0, 7);
+            },
+            label: function (item) {
+              var who = item.dataset.label;
+              return who + ': ' + Math.round(item.parsed.y).toLocaleString() + ' ns';
+            }
+          }
+        }
+      },
+      scales: {
+        x: {
+          ticks: { display: false },
+          grid: { display: false, drawBorder: false }
+        },
+        y: {
+          beginAtZero: true,
+          ticks: { color: '#8a9296', font: { size: 10 }, maxTicksLimit: 4, callback: function (v) { return v.toLocaleString(); } },
+          grid: { color: '#eef0f1', drawBorder: false },
+          border: { display: false }
+        }
+      },
+      elements: {
+        point: { radius: 0, hoverRadius: 4 },
+        line: { borderWidth: 1.6, tension: 0.25 }
+      }
+    };
+  }
+
+  var collectionsEl = document.getElementById('collections');
+  COLLECTIONS.forEach(function (col) {
+    var panel = document.createElement('section');
+    panel.className = 'collection';
+    panel.innerHTML =
+      '<div class="collection-head">' +
+        '<h3>' + col.title + '</h3>' +
+        '<div class="vs">vs <code>' + col.vs + '</code></div>' +
+      '</div>' +
+      '<div class="charts" data-collection="' + col.key + '"></div>';
+    var chartsEl = panel.querySelector('.charts');
+
+    col.ops.forEach(function (op) {
+      var ratio100k = ratioFor(col.key, op, 100000);
+      var ratio1k = ratioFor(col.key, op, 1000);
+      var displayRatio = ratio100k != null ? ratio100k : ratio1k;
+
+      var ratioStr, ratioCls, detail;
+      if (displayRatio == null) {
+        ratioStr = '&mdash;'; ratioCls = 'tie';
+        detail = 'no data';
+      } else if (displayRatio >= 1.05) {
+        ratioStr = displayRatio.toFixed(2) + '<span class="unit" style="font-size:13px;color:var(--fg-muted)">&times;</span> faster';
+        ratioCls = 'win';
+      } else if (displayRatio <= 0.95) {
+        ratioStr = (1 / displayRatio).toFixed(2) + '<span class="unit" style="font-size:13px;color:var(--fg-muted)">&times;</span> slower';
+        ratioCls = 'loss';
+      } else {
+        ratioStr = '~ parity';
+        ratioCls = 'tie';
+      }
+
+      if (displayRatio != null) {
+        var pair100k = latestIdx[col.key + '|' + op + '|100000'];
+        if (pair100k && pair100k.bcl != null && pair100k.celerity != null) {
+          detail = fmtNs(pair100k.celerity).replace('&mu;', 'µ') + ' vs ' + fmtNs(pair100k.bcl).replace('&mu;', 'µ') + ' @ 100k items';
+        } else {
+          var pair1k = latestIdx[col.key + '|' + op + '|1000'];
+          detail = fmtNs(pair1k.celerity).replace('&mu;', 'µ') + ' vs ' + fmtNs(pair1k.bcl).replace('&mu;', 'µ') + ' @ 1k items';
+        }
+      }
+
+      var cell = document.createElement('div');
+      cell.className = 'chart-cell';
+      cell.innerHTML =
+        '<div class="op">' + op + '</div>' +
+        '<div class="ratio ' + ratioCls + '">' + ratioStr + '</div>' +
+        '<div class="detail">' + detail + '</div>' +
+        '<canvas></canvas>';
+      chartsEl.appendChild(cell);
+
+      var canvas = cell.querySelector('canvas');
+      var s = seriesFor(col.key, op, 100000);
+
+      if (s.labels.length === 0 || (s.bcl.every(function (v) { return v == null; }) && s.celerity.every(function (v) { return v == null; }))) {
+        canvas.outerHTML = '<div class="empty">awaiting data</div>';
+        return;
+      }
+
+      var ctx = canvas.getContext('2d');
+      var chart = new Chart(ctx, {
+        type: 'line',
+        data: {
+          labels: s.labels.map(function () { return ''; }),
+          datasets: [
+            { label: '.NET BCL', data: s.bcl, borderColor: '#8a9296', backgroundColor: 'transparent', spanGaps: true },
+            { label: 'Celerity', data: s.celerity, borderColor: '#0d6e6e', backgroundColor: 'transparent', spanGaps: true }
+          ]
+        },
+        options: chartOptions()
+      });
+      chart.options.__labels = s.labels;
+    });
+
+    collectionsEl.appendChild(panel);
+  });
+
+  // ---- Header meta + footer ----
+  document.getElementById('run-count').textContent =
+    runs.length + ' run' + (runs.length === 1 ? '' : 's') + ' &middot; latest ' + new Date(latest.date).toISOString().slice(0, 10);
+
+  var sha = latest.commit.id.slice(0, 7);
+  document.getElementById('footer-build').innerHTML =
+    'Latest from <a href="' + latest.commit.url + '"><code>' + sha + '</code></a> &middot; ' +
+    new Date(latest.date).toUTCString();
+})();
+</script>
+
+</body>
+</html>

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,367 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Celerity &mdash; high-performance .NET collections</title>
+  <meta name="description" content="Celerity is a .NET library of specialised high-performance collections that beat the BCL on documented workloads. Open-source on GitHub, available on NuGet.">
+  <meta property="og:title" content="Celerity — high-performance .NET collections">
+  <meta property="og:description" content="Specialised dictionaries and sets that beat the .NET BCL on documented workloads. Live benchmarks tracked on every commit.">
+  <meta property="og:type" content="website">
+  <style>
+    :root {
+      --fg: #1a1d1f;
+      --fg-muted: #5a6166;
+      --fg-faint: #8a9296;
+      --bg: #ffffff;
+      --bg-alt: #f7f8f8;
+      --border: #e5e8ea;
+      --accent: #0d6e6e;
+      --accent-hover: #0a5757;
+      --accent-fg: #ffffff;
+      --win: #0d6e6e;
+      --font: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Helvetica Neue", Helvetica, Arial, sans-serif;
+      --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+    }
+    * { box-sizing: border-box; }
+    html, body { margin: 0; padding: 0; }
+    body {
+      font-family: var(--font);
+      color: var(--fg);
+      background: var(--bg);
+      line-height: 1.55;
+      font-size: 16px;
+      -webkit-font-smoothing: antialiased;
+    }
+    a { color: var(--accent); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    .wrap { max-width: 820px; margin: 0 auto; padding: 0 24px; }
+
+    /* Header */
+    header.site {
+      border-bottom: 1px solid var(--border);
+      padding: 18px 0;
+    }
+    header.site .wrap { display: flex; align-items: center; gap: 24px; }
+    header.site .brand {
+      font-weight: 600;
+      font-size: 17px;
+      color: var(--fg);
+      letter-spacing: -0.01em;
+    }
+    header.site .brand .dot { color: var(--accent); }
+    header.site nav { display: flex; gap: 18px; margin-left: auto; font-size: 14px; }
+    header.site nav a { color: var(--fg-muted); }
+    header.site nav a:hover { color: var(--fg); text-decoration: none; }
+    @media (max-width: 640px) {
+      header.site nav { gap: 12px; font-size: 13px; }
+    }
+
+    /* Hero */
+    section.hero { padding: 64px 0 32px; }
+    .hero h1 {
+      font-size: 38px;
+      line-height: 1.15;
+      margin: 0 0 14px;
+      letter-spacing: -0.025em;
+      font-weight: 600;
+      max-width: 640px;
+    }
+    .hero h1 .accent { color: var(--accent); }
+    .hero p.lead {
+      font-size: 17px;
+      color: var(--fg-muted);
+      max-width: 620px;
+      margin: 0 0 28px;
+    }
+    @media (max-width: 640px) {
+      section.hero { padding: 40px 0 24px; }
+      .hero h1 { font-size: 30px; }
+    }
+
+    /* Install block */
+    .install {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      flex-wrap: wrap;
+      margin-bottom: 28px;
+    }
+    .install pre {
+      margin: 0;
+      padding: 12px 16px;
+      background: var(--bg-alt);
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      font-family: var(--mono);
+      font-size: 14px;
+      color: var(--fg);
+      overflow-x: auto;
+    }
+    .install .copy-hint { font-size: 13px; color: var(--fg-faint); }
+
+    /* CTAs */
+    .ctas {
+      display: flex;
+      gap: 10px;
+      flex-wrap: wrap;
+      margin-bottom: 8px;
+    }
+    .btn {
+      display: inline-block;
+      padding: 10px 18px;
+      border-radius: 6px;
+      font-size: 14px;
+      font-weight: 500;
+      border: 1px solid var(--border);
+      color: var(--fg);
+      background: var(--bg);
+      transition: background 0.15s, color 0.15s, border-color 0.15s;
+    }
+    .btn:hover { text-decoration: none; background: var(--bg-alt); }
+    .btn.primary {
+      background: var(--accent);
+      color: var(--accent-fg);
+      border-color: var(--accent);
+    }
+    .btn.primary:hover { background: var(--accent-hover); border-color: var(--accent-hover); }
+
+    /* Stats */
+    .section-head {
+      margin: 56px 0 14px;
+      display: flex;
+      align-items: baseline;
+      justify-content: space-between;
+      gap: 16px;
+    }
+    .section-head h2 {
+      margin: 0;
+      font-size: 14px;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--fg-muted);
+      font-weight: 600;
+    }
+    .section-head .meta { font-size: 13px; color: var(--fg-faint); }
+    .section-head .meta a { color: var(--fg-faint); }
+
+    .stats {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 12px;
+    }
+    @media (max-width: 720px) { .stats { grid-template-columns: 1fr; } }
+    .stat {
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 18px 20px;
+      background: var(--bg);
+    }
+    .stat .label {
+      font-size: 12px;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: var(--fg-muted);
+      margin-bottom: 8px;
+    }
+    .stat .value {
+      font-size: 28px;
+      font-weight: 600;
+      letter-spacing: -0.01em;
+      color: var(--win);
+    }
+    .stat .value .unit {
+      font-size: 15px;
+      color: var(--fg-muted);
+      font-weight: 500;
+      margin-left: 4px;
+    }
+    .stat .value.tie { color: var(--fg-muted); }
+    .stat .sub { font-size: 12px; color: var(--fg-faint); margin-top: 6px; }
+
+    /* What it ships */
+    .ships {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 14px;
+      margin-top: 12px;
+    }
+    @media (max-width: 720px) { .ships { grid-template-columns: 1fr; } }
+    .ship {
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 16px 18px;
+    }
+    .ship code {
+      font-family: var(--mono);
+      font-size: 13px;
+      color: var(--fg);
+    }
+    .ship .desc {
+      font-size: 13px;
+      color: var(--fg-muted);
+      margin-top: 4px;
+    }
+
+    /* About */
+    .about {
+      font-size: 15px;
+      color: var(--fg-muted);
+      line-height: 1.65;
+      max-width: 680px;
+    }
+    .about strong { color: var(--fg); font-weight: 600; }
+
+    /* Footer */
+    footer.site {
+      margin: 72px 0 32px;
+      padding-top: 24px;
+      border-top: 1px solid var(--border);
+      font-size: 13px;
+      color: var(--fg-faint);
+    }
+    footer.site .wrap { display: flex; justify-content: space-between; flex-wrap: wrap; gap: 12px; }
+    footer.site a { color: var(--fg-faint); }
+    footer.site code { font-family: var(--mono); font-size: 12px; }
+  </style>
+</head>
+<body>
+
+<header class="site">
+  <div class="wrap">
+    <a href="./" class="brand">Celerity<span class="dot">.</span></a>
+    <nav>
+      <a href="dev/bench/">Benchmarks</a>
+      <a href="https://github.com/marius-bughiu/Celerity">GitHub</a>
+      <a href="https://www.nuget.org/packages/Celerity.Collections/">NuGet</a>
+    </nav>
+  </div>
+</header>
+
+<main class="wrap">
+  <section class="hero">
+    <h1>High-performance .NET collections that <span class="accent">beat the BCL</span> on documented workloads.</h1>
+    <p class="lead">Celerity ships specialised dictionaries and sets with struct-based hashers, zero-cost generic dispatch, and continuous performance tracking on every commit. If a type doesn't outperform its <code>System.Collections.Generic</code> counterpart on a real benchmark, it doesn't ship.</p>
+
+    <div class="install">
+      <pre>dotnet add package Celerity.Collections</pre>
+    </div>
+
+    <div class="ctas">
+      <a class="btn primary" href="dev/bench/">View live benchmarks &rarr;</a>
+      <a class="btn" href="https://github.com/marius-bughiu/Celerity">GitHub</a>
+      <a class="btn" href="https://www.nuget.org/packages/Celerity.Collections/">NuGet</a>
+    </div>
+  </section>
+
+  <div class="section-head">
+    <h2>Latest measurement vs .NET BCL</h2>
+    <span class="meta"><a href="dev/bench/">Full dashboard &rarr;</a></span>
+  </div>
+  <div class="stats" id="stats">
+    <div class="stat"><div class="label">Lookup</div><div class="value tie">&mdash;</div><div class="sub">vs Dictionary / HashSet</div></div>
+    <div class="stat"><div class="label">Insert</div><div class="value tie">&mdash;</div><div class="sub">vs Dictionary / HashSet</div></div>
+    <div class="stat"><div class="label">Remove</div><div class="value tie">&mdash;</div><div class="sub">vs Dictionary / HashSet</div></div>
+  </div>
+
+  <div class="section-head">
+    <h2>What ships in the box</h2>
+  </div>
+  <div class="ships">
+    <div class="ship"><code>IntDictionary&lt;TValue&gt;</code><div class="desc">int-keyed dictionary, default Wang hash.</div></div>
+    <div class="ship"><code>LongDictionary&lt;TValue&gt;</code><div class="desc">long-keyed dictionary, default Wang hash.</div></div>
+    <div class="ship"><code>CelerityDictionary&lt;K, V, H&gt;</code><div class="desc">Generic dictionary with a struct hasher constraint.</div></div>
+    <div class="ship"><code>IntSet</code><div class="desc">int-keyed set, default Wang hash.</div></div>
+    <div class="ship"><code>CeleritySet&lt;T, H&gt;</code><div class="desc">Generic set with a struct hasher constraint.</div></div>
+    <div class="ship"><code>Celerity.Hashing</code><div class="desc">Wang, Murmur3, FNV-1a, Guid, default fallback.</div></div>
+  </div>
+
+  <div class="section-head">
+    <h2>Design notes</h2>
+  </div>
+  <div class="about">
+    Hashers are <strong>structs</strong> passed as generic constraints (<code>where THasher : struct, IHashProvider&lt;T&gt;</code>) so the JIT devirtualizes and inlines <code>Hash()</code> on the probe path. Dictionaries implement <code>IReadOnlyDictionary&lt;TKey, TValue&gt;</code>, ship allocation-free struct enumerators, and handle <code>default(TKey)</code> out-of-band so the zero / null key never collides with the empty-slot sentinel. Celerity is single-threaded and does not guarantee iteration order &mdash; if you need either, use <code>ConcurrentDictionary&lt;,&gt;</code> or stay on the BCL.
+  </div>
+</main>
+
+<footer class="site">
+  <div class="wrap">
+    <span id="footer-build">MIT-licensed &middot; Open source on <a href="https://github.com/marius-bughiu/Celerity">GitHub</a></span>
+    <span><a href="dev/bench/">Live benchmarks</a> &middot; <a href="https://github.com/marius-bughiu/Celerity/blob/main/CHANGELOG.md">Changelog</a> &middot; <a href="https://github.com/marius-bughiu/Celerity/blob/main/ROADMAP.md">Roadmap</a></span>
+  </div>
+</footer>
+
+<script src="dev/bench/data.js"></script>
+<script>
+(function () {
+  'use strict';
+
+  var BCL_TYPES = new Set(['Dictionary', 'HashSet']);
+  var ITEM_COUNT = 100000;
+
+  var data = window.BENCHMARK_DATA;
+  if (!data || !data.entries || !data.entries['Celerity Benchmarks'] || data.entries['Celerity Benchmarks'].length === 0) return;
+
+  var runs = data.entries['Celerity Benchmarks'];
+  var latest = runs[runs.length - 1];
+
+  function parseName(name) {
+    var m = name.match(/^(\w+)Benchmark\.(\w+?)_(\w+)\(ItemCount:\s*(\d+)\)$/);
+    if (!m) return null;
+    return { collection: m[1], typeName: m[2], op: m[3], itemCount: parseInt(m[4], 10), isBcl: BCL_TYPES.has(m[2]) };
+  }
+
+  // Index: collection|op|itemCount -> { bcl, celerity }
+  var idx = {};
+  latest.benches.forEach(function (b) {
+    var p = parseName(b.name);
+    if (!p) return;
+    var key = p.collection + '|' + p.op + '|' + p.itemCount;
+    if (!idx[key]) idx[key] = {};
+    idx[key][p.isBcl ? 'bcl' : 'celerity'] = b.value;
+  });
+
+  function bestSpeedup(opAliases) {
+    var best = null;
+    Object.keys(idx).forEach(function (key) {
+      var parts = key.split('|');
+      if (opAliases.indexOf(parts[1]) === -1) return;
+      if (parseInt(parts[2], 10) !== ITEM_COUNT) return;
+      var pair = idx[key];
+      if (pair.bcl == null || pair.celerity == null) return;
+      var ratio = pair.bcl / pair.celerity;
+      if (best == null || ratio > best.ratio) best = { ratio: ratio, collection: parts[0], op: parts[1] };
+    });
+    return best;
+  }
+
+  var groups = [
+    { i: 0, aliases: ['Lookup', 'Contains'], label: 'lookup-type ops' },
+    { i: 1, aliases: ['Insert', 'Add'],      label: 'insert-type ops' },
+    { i: 2, aliases: ['Remove'],             label: 'remove ops' }
+  ];
+
+  var statEls = document.querySelectorAll('#stats .stat');
+  groups.forEach(function (g) {
+    var best = bestSpeedup(g.aliases);
+    var el = statEls[g.i];
+    if (!best) return;
+    var valueEl = el.querySelector('.value');
+    var r = best.ratio;
+    if (r >= 1.05) {
+      valueEl.innerHTML = r.toFixed(2) + '<span class="unit">&times; faster</span>';
+      valueEl.classList.remove('tie');
+    } else if (r <= 0.95) {
+      valueEl.innerHTML = (1 / r).toFixed(2) + '<span class="unit">&times; slower</span>';
+      valueEl.classList.remove('tie');
+      valueEl.style.color = 'var(--loss, #b54545)';
+    } else {
+      valueEl.textContent = '~ parity';
+    }
+    el.querySelector('.sub').innerHTML = 'best result: ' + best.collection + ' &middot; ' + best.op + ' &middot; ' + (ITEM_COUNT / 1000) + 'k items';
+  });
+})();
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary

Follow-up to [#96](https://github.com/marius-bughiu/Celerity/pull/96). Three issues remained after the initial benchmark CI landed:

1. **Discoverability**: README had no link to the dashboard, and the gh-pages root 404'd. Visitors couldn't find the live numbers.
2. **Dashboard design**: the action's auto-generated chart UI was unbranded and generic.
3. **Suspected PR/main data conflation**: investigated and resolved as a non-issue — both data points came from legitimate `main` pushes (the PR #96 merge + the v1.2.1 release commit). The `auto-push: ${{ github.event_name == 'push' }}` guard works correctly.

This PR addresses #1 and #2.

## What's in here

- **`web/index.html`** — landing page at the gh-pages root. Hero with one-line install, three CTAs (Live benchmarks / GitHub / NuGet), live stats computed from `data.js` ("best lookup speedup: X.Y× faster"), "what ships" grid, design notes section.
- **`web/dev/bench/index.html`** — custom dashboard replacing the action's default. Headline stat row, methodology note, then a panel per collection with one sparkline per op showing both BCL baseline and Celerity over time. Speedup label and absolute ns for each.
- **Sync step in `ci.yml`** — runs after the benchmark action on `main` pushes only. Uses `git worktree add` to check out gh-pages, copies the two HTML files, commits/pushes if changed. Leaves `data.js` (action-managed) untouched.
- **README** — Live benchmarks badge in the header row + a callout under `## Benchmarks` linking to the dashboard. Kept the existing static `CelerityDictionary` table since it's a useful quick-reference for README skimmers.
- **`web/dev/bench/.gitignore`** — keeps `data.js` out of `main` (it belongs only on gh-pages). Allows a developer to drop a local copy for previewing the dashboard with real data.

## Design choices

- Visual language matches the README: system font stack, single teal accent (`#0d6e6e`), generous whitespace, no emoji, no marketing fluff.
- Self-contained HTML files — embedded CSS, no build step. Chart.js loaded from CDN.
- Both pages are mobile responsive (single breakpoint at ~720px).
- Headline stats compute the **best speedup at 100k items** per op category (lookup-type / insert-type / remove). Honest framing — labels say "best result: <collection> · <op> · 100k items" so readers know it's not an across-the-board claim.

## Test plan

- [x] Local preview of both files with real `data.js` (copied from gh-pages) — charts render, stats compute, links resolve.
- [ ] CI runs on this PR — confirm `benchmarks` job still completes; the new sync step should be skipped (per `if: github.event_name == 'push' && github.ref == 'refs/heads/main'`).
- [ ] After merge: confirm the sync step runs, commits to gh-pages, and:
  - `https://marius-bughiu.github.io/Celerity/` shows the landing page (no more 404)
  - `https://marius-bughiu.github.io/Celerity/dev/bench/` shows the custom dashboard
- [ ] README badge in the header renders + clicks through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)