### PR TITLE
bench: fix Remove benchmarks timing no-ops on empty collections

### DIFF
--- a/src/Celerity.Benchmarks/CelerityDictionaryBenchmark.cs
+++ b/src/Celerity.Benchmarks/CelerityDictionaryBenchmark.cs
@@ -75,6 +75,16 @@ public class CelerityDictionaryBenchmark
         }
     }
 
+    [IterationSetup(Target = nameof(Dictionary_Remove))]
+    public void SetupForDictionaryRemove()
+    {
+        dictionary = new Dictionary<int, int>(ItemCount);
+        foreach (var key in keys)
+        {
+            dictionary[key] = key;
+        }
+    }
+
     [Benchmark(Baseline = true)]
     [BenchmarkCategory("Remove")]
     public void Dictionary_Remove()
@@ -82,6 +92,16 @@ public class CelerityDictionaryBenchmark
         foreach (var key in keys)
         {
             dictionary.Remove(key);
+        }
+    }
+
+    [IterationSetup(Target = nameof(CelerityDictionary_Remove))]
+    public void SetupForCelerityDictionaryRemove()
+    {
+        celerityDictionary = new CelerityDictionary<int, int, Int32WangNaiveHasher>(ItemCount);
+        foreach (var key in keys)
+        {
+            celerityDictionary[key] = key;
         }
     }
 

--- a/src/Celerity.Benchmarks/CeleritySetBenchmark.cs
+++ b/src/Celerity.Benchmarks/CeleritySetBenchmark.cs
@@ -79,6 +79,16 @@ public class CeleritySetBenchmark
         return result;
     }
 
+    [IterationSetup(Target = nameof(HashSet_Remove))]
+    public void SetupForHashSetRemove()
+    {
+        hashSet = new HashSet<int>(ItemCount);
+        foreach (var key in keys)
+        {
+            hashSet.Add(key);
+        }
+    }
+
     [Benchmark(Baseline = true)]
     [BenchmarkCategory("Remove")]
     public void HashSet_Remove()
@@ -86,6 +96,16 @@ public class CeleritySetBenchmark
         foreach (var key in keys)
         {
             hashSet.Remove(key);
+        }
+    }
+
+    [IterationSetup(Target = nameof(CeleritySet_Remove))]
+    public void SetupForCeleritySetRemove()
+    {
+        celeritySet = new CeleritySet<int, Int32WangNaiveHasher>(ItemCount);
+        foreach (var key in keys)
+        {
+            celeritySet.Add(key);
         }
     }
 

--- a/src/Celerity.Benchmarks/IntDictionaryBenchmark.cs
+++ b/src/Celerity.Benchmarks/IntDictionaryBenchmark.cs
@@ -74,6 +74,16 @@ public class IntDictionaryBenchmark
         }
     }
 
+    [IterationSetup(Target = nameof(Dictionary_Remove))]
+    public void SetupForDictionaryRemove()
+    {
+        dictionary = new Dictionary<int, int>(ItemCount);
+        foreach (var key in keys)
+        {
+            dictionary[key] = key;
+        }
+    }
+
     [Benchmark(Baseline = true)]
     [BenchmarkCategory("Remove")]
     public void Dictionary_Remove()
@@ -81,6 +91,16 @@ public class IntDictionaryBenchmark
         foreach (var key in keys)
         {
             dictionary.Remove(key);
+        }
+    }
+
+    [IterationSetup(Target = nameof(IntDictionary_Remove))]
+    public void SetupForIntDictionaryRemove()
+    {
+        intDictionary = new IntDictionary<int>(ItemCount);
+        foreach (var key in keys)
+        {
+            intDictionary[key] = key;
         }
     }
 

--- a/src/Celerity.Benchmarks/IntSetBenchmark.cs
+++ b/src/Celerity.Benchmarks/IntSetBenchmark.cs
@@ -78,6 +78,16 @@ public class IntSetBenchmark
         return result;
     }
 
+    [IterationSetup(Target = nameof(HashSet_Remove))]
+    public void SetupForHashSetRemove()
+    {
+        hashSet = new HashSet<int>(ItemCount);
+        foreach (var key in keys)
+        {
+            hashSet.Add(key);
+        }
+    }
+
     [Benchmark(Baseline = true)]
     [BenchmarkCategory("Remove")]
     public void HashSet_Remove()
@@ -85,6 +95,16 @@ public class IntSetBenchmark
         foreach (var key in keys)
         {
             hashSet.Remove(key);
+        }
+    }
+
+    [IterationSetup(Target = nameof(IntSet_Remove))]
+    public void SetupForIntSetRemove()
+    {
+        intSet = new IntSet(ItemCount);
+        foreach (var key in keys)
+        {
+            intSet.Add(key);
         }
     }
 

--- a/src/Celerity.Benchmarks/LongDictionaryBenchmark.cs
+++ b/src/Celerity.Benchmarks/LongDictionaryBenchmark.cs
@@ -74,6 +74,16 @@ public class LongDictionaryBenchmark
         }
     }
 
+    [IterationSetup(Target = nameof(Dictionary_Remove))]
+    public void SetupForDictionaryRemove()
+    {
+        dictionary = new Dictionary<long, int>(ItemCount);
+        for (int i = 0; i < keys.Length; i++)
+        {
+            dictionary[keys[i]] = i;
+        }
+    }
+
     [Benchmark(Baseline = true)]
     [BenchmarkCategory("Remove")]
     public void Dictionary_Remove()
@@ -81,6 +91,16 @@ public class LongDictionaryBenchmark
         foreach (var key in keys)
         {
             dictionary.Remove(key);
+        }
+    }
+
+    [IterationSetup(Target = nameof(LongDictionary_Remove))]
+    public void SetupForLongDictionaryRemove()
+    {
+        longDictionary = new LongDictionary<int>(ItemCount);
+        for (int i = 0; i < keys.Length; i++)
+        {
+            longDictionary[keys[i]] = i;
         }
     }
 


### PR DESCRIPTION
## Summary

All five `*Remove` benchmarks in `src/Celerity.Benchmarks/` were timing no-ops on empty collections. Pre-population happened in `[GlobalSetup]` (runs once per instance), so after the first measurement invocation drained the dict/set, every subsequent iteration just iterated `keys` and called `Remove` on an empty hash table. Both the absolute numbers and the `Ratio` column were skewed as a result.

The fix is to switch each `*_Remove` benchmark to its own per-target `[IterationSetup]`, so the collection is rebuilt before every iteration. `[GlobalSetup]` is retained because `Lookup`/`Contains` benchmarks still depend on the field-level dict/set being populated across iterations.

Per-target setups (rather than one shared setup) mean each benchmark only pays for its own collection's rebuild, not its sibling's.

## Why this is correct

BDN auto-reduces `UnrollFactor` and `InvocationCount` to 1 when `[IterationSetup]` is present, so each iteration calls the benchmark method exactly once on a freshly populated collection — which is exactly the contract a Remove benchmark needs.

## Verification

Local run on net10 (only SDK installed on this box; project still targets net8.0) of `--filter '*Remove*' --warmupCount 2 --iterationCount 3` produced stable per-iteration measurements, e.g.:

```
IntSet_Remove (ItemCount=100000):
  WorkloadActual 1: 809.8 us
  WorkloadActual 2: 849.0 us
  WorkloadActual 3: 809.1 us
```

Under the bug, iterations 2-3 would have been near-zero (no-op on empty). The fact that all three are within ~5% of each other confirms each iteration sees a freshly populated collection.

## Caveats

- BDN emits a `MinIterationTime` warning for the 1000-item parameter because per-iteration work (~10-28us) is small relative to `[IterationSetup]` overhead. This is an inherent tradeoff of `[IterationSetup]` — without unrolling, small workloads can't be amplified. The 100K parameter is well-sized and unaffected.
- The committed `TargetFramework` is `net8.0`. CI will run on net8.0; the local verification ran on net10 via roll-forward. The structural fix is runtime-agnostic.

## Files changed

- `src/Celerity.Benchmarks/CelerityDictionaryBenchmark.cs`
- `src/Celerity.Benchmarks/IntDictionaryBenchmark.cs`
- `src/Celerity.Benchmarks/LongDictionaryBenchmark.cs`
- `src/Celerity.Benchmarks/CeleritySetBenchmark.cs`
- `src/Celerity.Benchmarks/IntSetBenchmark.cs`

## Test plan

- [ ] CI benchmark job completes successfully
- [ ] Spot-check that Remove timings in the published dashboard are now larger than (or at least comparable to) Insert timings — the old numbers were unrealistically small
- [ ] Confirm the `Ratio` column for Remove categories reflects real work, not a no-op race

🤖 Generated with [Claude Code](https://claude.com/claude-code)