### PR TITLE
ci: add nightly preview release workflow

### DIFF
--- a/.github/workflows/nightly-preview.yml
+++ b/.github/workflows/nightly-preview.yml
@@ -1,0 +1,81 @@
+name: Nightly preview
+
+on:
+  schedule:
+    # 15:00 UTC = 18:00 Europe/Bucharest (EEST, summer). Drifts to 17:00 local in EET winter.
+    - cron: '0 15 * * *'
+  workflow_dispatch:
+
+env:
+  NuGetDirectory: ${{ github.workspace }}/nuget
+
+defaults:
+  run:
+    shell: pwsh
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: src
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+          filter: tree:0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Restore workloads
+        run: dotnet workload restore
+
+      - name: Restore dependencies
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build --no-restore
+
+      - name: Create nuget package
+        run: dotnet pack --configuration Release --output ${{ env.NuGetDirectory }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: nuget
+          if-no-files-found: error
+          retention-days: 7
+          path: ${{ env.NuGetDirectory }}/*.nupkg
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: [ build ]
+    environment: nuget-publish
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: nuget
+          path: ${{ env.NuGetDirectory }}
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Authenticate to NuGet.org via trusted publishing
+        id: nuget-login
+        uses: NuGet/login@v1
+        with:
+          user: marius.bughiu
+
+      - name: Publish NuGet package
+        run: |
+          foreach($file in (Get-ChildItem "${{ env.NuGetDirectory }}" -Recurse -Include *.nupkg)) {
+              dotnet nuget push $file --api-key "${{ steps.nuget-login.outputs.NUGET_API_KEY }}" --source https://api.nuget.org/v3/index.json --skip-duplicate
+          }


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/nightly-preview.yml` that publishes a prerelease `Celerity.Collections` package from `main` daily at **15:00 UTC** (18:00 Europe/Bucharest in EEST, 17:00 in EET winter).
- Mirrors the `build` + `deploy` jobs of `release.yml`; reuses NuGet trusted publishing (`NuGet/login@v1`, environment `nuget-publish`) and the same `--skip-duplicate` push.
- No `csproj`/MinVer changes: MinVer's existing `beta` default prerelease identifier already produces versions like `1.2.2-beta.0.N` between tagged releases, which NuGet treats as prereleases.

## Why
Between tagged releases, consumers had no way to try what's on `main`. A nightly preview closes that gap without disturbing the existing tag-triggered release flow.

## One-time external setup required
NuGet trusted publishing binds to a specific repo + workflow file + environment. **Before the first scheduled or manual run can publish**, add a trusted-publishing policy on nuget.org:

- nuget.org → Account → Trusted Publishing → add policy
- Repo: `marius-bughiu/Celerity`
- Workflow: `.github/workflows/nightly-preview.yml`
- Environment: `nuget-publish`

Without this, `NuGet/login@v1` will fail with an OIDC authorization error.

## Test plan
- [ ] After merge, configure the trusted publishing policy on nuget.org (see above).
- [ ] Smoke-test with `gh workflow run "Nightly preview"` rather than waiting for 15:00 UTC.
- [ ] Confirm the `build` job produces `Celerity.Collections.<X.Y.Z>-beta.0.<N>.nupkg`.
- [ ] Confirm the `deploy` job pushes successfully (or reports "already exists" + skip on a re-run).
- [ ] Verify nuget.org lists the new prerelease (search with "Include prerelease" enabled).
- [ ] Re-run `workflow_dispatch` with no new `main` commits; push step should no-op via `--skip-duplicate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)