### PR TITLE
perf(collections): Int64 naive hasher + inlining + Unsafe.Add bounds-check elimination

### DIFF
--- a/src/Celerity.Tests/Collections/AddAndTryAddTests.cs
+++ b/src/Celerity.Tests/Collections/AddAndTryAddTests.cs
@@ -339,4 +339,59 @@ public class AddAndTryAddTests
 
         Assert.Throws<ArgumentException>(() => map.Add("key", 3));
     }
+
+    [Fact]
+    public void LongDictionary_Add_ThenIndexerOverwrite_ShouldSucceed()
+    {
+        // Mirror of the Int / Celerity dictionary regression test. Pins down
+        // that the indexer setter, after the ProbeForInsert(out bool wasEmpty)
+        // refactor, does not bump _count when the slot was already occupied
+        // by the same key. The Long path was the only dictionary not covered
+        // in this file before.
+        var map = new LongDictionary<int>();
+        map.Add(3L, 30);
+        map[3L] = 300;
+
+        Assert.Equal(1, map.Count);
+        Assert.Equal(300, map[3L]);
+
+        Assert.Throws<ArgumentException>(() => map.Add(3L, 3000));
+    }
+
+    [Fact]
+    public void Dictionaries_RepeatedIndexerOverwrite_ShouldKeepCountStable()
+    {
+        // Issue a long sequence of overwrites on every dictionary shape and
+        // assert Count never drifts past the insert count. With the wasEmpty
+        // out-bool on ProbeForInsert, an overwrite must hit the `wasEmpty =
+        // false` branch every time after the first set; a regression that
+        // wired the wrong branch would inflate Count linearly.
+        var intDict = new IntDictionary<int>();
+        var longDict = new LongDictionary<int>();
+        var celDict = new CelerityDictionary<int, int, Int32WangNaiveHasher>();
+
+        const int Inserts = 32;
+        const int Overwrites = 100;
+
+        for (int i = 1; i <= Inserts; i++)
+        {
+            intDict[i] = i;
+            longDict[(long)i] = i;
+            celDict[i] = i;
+        }
+
+        for (int round = 0; round < Overwrites; round++)
+        {
+            for (int i = 1; i <= Inserts; i++)
+            {
+                intDict[i] = round;
+                longDict[(long)i] = round;
+                celDict[i] = round;
+            }
+        }
+
+        Assert.Equal(Inserts, intDict.Count);
+        Assert.Equal(Inserts, longDict.Count);
+        Assert.Equal(Inserts, celDict.Count);
+    }
 }

--- a/src/Celerity.Tests/Hashing/Int64WangNaiveHasherTests.cs
+++ b/src/Celerity.Tests/Hashing/Int64WangNaiveHasherTests.cs
@@ -1,0 +1,156 @@
+using Celerity.Collections;
+using Celerity.Hashing;
+
+namespace Celerity.Tests.Hashing;
+
+public class Int64WangNaiveHasherTests
+{
+    private readonly Int64WangNaiveHasher _hasher = new Int64WangNaiveHasher();
+
+    // The naive hasher folds three 32-bit windows of the key into one int.
+    // The formula is short enough to act as the spec, so the theory cases
+    // compute the expected value inline rather than hard-coding anchors.
+    private static int Expected(long key) =>
+        (int)key ^ (int)((ulong)key >> 32) ^ (int)((ulong)key >> 16);
+
+    [Theory]
+    [InlineData(0L)]
+    [InlineData(1L)]
+    [InlineData(-1L)]
+    [InlineData(42L)]
+    [InlineData(long.MaxValue)]
+    [InlineData(long.MinValue)]
+    [InlineData(1234567890123456789L)]
+    [InlineData(0x0000_FFFF_FFFF_FFFFL)]
+    [InlineData(0x1234_5678_9ABC_DEF0L)]
+    public void Hash_MatchesFormula(long input)
+    {
+        Assert.Equal(Expected(input), _hasher.Hash(input));
+    }
+
+    [Fact]
+    public void Hash_IsDeterministic_AcrossCalls()
+    {
+        long value = 1234567890123456789L;
+        int result1 = _hasher.Hash(value);
+        int result2 = _hasher.Hash(value);
+        Assert.Equal(result1, result2);
+    }
+
+    [Fact]
+    public void Hash_IsDeterministic_AcrossInstances()
+    {
+        // Hashers are structs with no state; two independently-constructed
+        // instances must produce identical output for the same input.
+        long value = -1234567890987654321L;
+        int a = new Int64WangNaiveHasher().Hash(value);
+        int b = new Int64WangNaiveHasher().Hash(value);
+        Assert.Equal(a, b);
+    }
+
+    [Fact]
+    public void Hash_HighBits_InfluenceResult()
+    {
+        // A regression guard against any future change that accidentally
+        // discards the upper 32 bits. Flip a single bit in the top half and
+        // assert the hash moves with it.
+        int low = _hasher.Hash(1L);
+        int high = _hasher.Hash(1L | (1L << 48));
+        Assert.NotEqual(low, high);
+    }
+
+    [Fact]
+    public void Hash_MidBits_InfluenceResult()
+    {
+        // The naive hasher folds the >>16 window in to keep bits 16-47 alive.
+        // A version that only XORed (int)key with (int)(key >> 32) would lose
+        // the entire byte at position [2..6]; this test pins that down.
+        int baseline = _hasher.Hash(0L);
+        int withMidBit = _hasher.Hash(1L << 20);
+        Assert.NotEqual(baseline, withMidBit);
+    }
+
+    [Fact]
+    public void Hash_ConsecutiveSmallInputs_AreDistinct()
+    {
+        // For sequential keys 0..999 the low 32 bits dominate, so the result
+        // is just (int)key in that range — no collisions expected.
+        var seen = new HashSet<int>();
+        for (long i = 0; i < 1000; i++)
+        {
+            Assert.True(seen.Add(_hasher.Hash(i)),
+                $"Unexpected collision at input {i}.");
+        }
+    }
+
+    [Fact]
+    public void Hash_BitStridedInputs_AreDistinct()
+    {
+        // Keys constructed by setting a single high-half bit at a time. The
+        // naive hasher must spread these across distinct buckets — a hasher
+        // that ignored the upper half would map every one of these to 0.
+        var seen = new HashSet<int>();
+        for (int bit = 32; bit < 64; bit++)
+        {
+            long key = 1L << bit;
+            Assert.True(seen.Add(_hasher.Hash(key)),
+                $"Collision at bit {bit} (key = 0x{key:X16}).");
+        }
+    }
+
+    [Fact]
+    public void Hash_DoesNotThrow()
+    {
+        long[] testValues =
+        {
+            0L, 1L, -1L, long.MaxValue, long.MinValue,
+            1234567890123456789L, -1234567890987654321L
+        };
+
+        foreach (long val in testValues)
+        {
+            var ex = Record.Exception(() => _hasher.Hash(val));
+            Assert.Null(ex);
+        }
+    }
+
+    [Fact]
+    public void Int64WangNaiveHasher_CanDriveLongDictionary()
+    {
+        // Integration check: the new default for LongDictionary<TValue> must
+        // satisfy the hasher constraint end-to-end, including the out-of-band
+        // zero-key slot.
+        var dict = new LongDictionary<string>();
+
+        dict[0L] = "zero";
+        dict[1L] = "one";
+        dict[-1L] = "neg-one";
+        dict[42L] = "forty-two";
+
+        Assert.Equal(4, dict.Count);
+        Assert.Equal("zero", dict[0L]);
+        Assert.Equal("one", dict[1L]);
+        Assert.Equal("neg-one", dict[-1L]);
+        Assert.Equal("forty-two", dict[42L]);
+        Assert.True(dict.ContainsKey(0L));
+        Assert.False(dict.ContainsKey(999L));
+    }
+
+    [Fact]
+    public void Int64WangNaiveHasher_CanDriveLongSet()
+    {
+        var set = new LongSet();
+
+        set.Add(0L);
+        set.Add(1L);
+        set.Add(-1L);
+        set.Add(42L);
+
+        Assert.Equal(4, set.Count);
+        Assert.True(set.Contains(0L));
+        Assert.True(set.Contains(1L));
+        Assert.True(set.Contains(-1L));
+        Assert.True(set.Contains(42L));
+        Assert.False(set.Contains(999L));
+    }
+}

--- a/src/Celerity/Collections/CelerityDictionary.cs
+++ b/src/Celerity/Collections/CelerityDictionary.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using System.Runtime.CompilerServices;
 using Celerity.Hashing;
 
 namespace Celerity.Collections;
@@ -646,6 +647,7 @@ public class CelerityDictionary<TKey, TValue, THasher>
     private static bool IsDefaultKey(TKey key) =>
         EqualityComparer<TKey>.Default.Equals(key, default(TKey));
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private int ProbeForInsert(TKey key)
     {
         int size = _keys.Length;
@@ -662,6 +664,7 @@ public class CelerityDictionary<TKey, TValue, THasher>
         return index;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private int ProbeForKey(TKey key)
     {
         int size = _keys.Length;
@@ -721,6 +724,7 @@ public class CelerityDictionary<TKey, TValue, THasher>
     // surviving cluster entry is visited exactly once and most are not
     // moved at all — the work-per-cluster collapses from quadratic to
     // linear, which is the bulk of the Remove speedup.
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void BackwardShiftRemove(int startIndex)
     {
         TKey?[] keys = _keys;

--- a/src/Celerity/Collections/CelerityDictionary.cs
+++ b/src/Celerity/Collections/CelerityDictionary.cs
@@ -171,8 +171,7 @@ public class CelerityDictionary<TKey, TValue, THasher>
                 Resize();
             }
 
-            int index = ProbeForInsert(key);
-            bool isNewEntry = EqualityComparer<TKey>.Default.Equals(_keys[index], default(TKey));
+            int index = ProbeForInsert(key, out bool isNewEntry);
 
             _keys[index] = key;
             _values[index] = value;
@@ -364,14 +363,14 @@ public class CelerityDictionary<TKey, TValue, THasher>
         // duplicate check so a duplicate-at-threshold call cannot silently
         // swap out the backing arrays under an active enumerator (see
         // issue #92).
-        int index = ProbeForInsert(key);
-        if (!EqualityComparer<TKey>.Default.Equals(_keys[index], default(TKey)))
+        int index = ProbeForInsert(key, out bool wasEmpty);
+        if (!wasEmpty)
             return false;
 
         if (_count >= _threshold)
         {
             Resize();
-            index = ProbeForInsert(key);
+            index = ProbeForInsert(key, out _);
         }
 
         _keys[index] = key;
@@ -647,21 +646,26 @@ public class CelerityDictionary<TKey, TValue, THasher>
     private static bool IsDefaultKey(TKey key) =>
         EqualityComparer<TKey>.Default.Equals(key, default(TKey));
 
+    // Returns the slot the caller should write into. <paramref name="wasEmpty"/>
+    // tells the caller whether the slot was previously empty (true → new entry,
+    // bump _count) or already held the same key (false → overwrite). Hoisting
+    // that signal out of the probe lets the indexer setter and TryAdd skip a
+    // redundant `_keys[index]` re-read + comparer dispatch on the insert path.
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private int ProbeForInsert(TKey key)
+    private int ProbeForInsert(TKey key, out bool wasEmpty)
     {
-        int size = _keys.Length;
+        TKey?[] keys = _keys;
+        int mask = keys.Length - 1;
+        var comparer = EqualityComparer<TKey>.Default;
+        int index = _hasher.Hash(key) & mask;
 
-        // Only works when size is a power of two
-        int index = _hasher.Hash(key) & (size - 1);
-
-        while (!EqualityComparer<TKey>.Default.Equals(_keys[index], default(TKey)) &&
-               !EqualityComparer<TKey>.Default.Equals(_keys[index], key))
+        while (true)
         {
-            index = (index + 1) & (size - 1);
+            TKey? slot = keys[index];
+            if (comparer.Equals(slot, default(TKey))) { wasEmpty = true; return index; }
+            if (comparer.Equals(slot, key)) { wasEmpty = false; return index; }
+            index = (index + 1) & mask;
         }
-
-        return index;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Celerity/Collections/CelerityDictionary.cs
+++ b/src/Celerity/Collections/CelerityDictionary.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using Celerity.Hashing;
 
 namespace Celerity.Collections;
@@ -173,8 +174,10 @@ public class CelerityDictionary<TKey, TValue, THasher>
 
             int index = ProbeForInsert(key, out bool isNewEntry);
 
-            _keys[index] = key;
-            _values[index] = value;
+            TKey?[] keys = _keys;
+            TValue?[] values = _values;
+            Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(keys), (nint)(uint)index) = key;
+            Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(values), (nint)(uint)index) = value;
 
             if (isNewEntry)
                 _count++;
@@ -373,8 +376,10 @@ public class CelerityDictionary<TKey, TValue, THasher>
             index = ProbeForInsert(key, out _);
         }
 
-        _keys[index] = key;
-        _values[index] = value;
+        TKey?[] keys = _keys;
+        TValue?[] values = _values;
+        Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(keys), (nint)(uint)index) = key;
+        Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(values), (nint)(uint)index) = value;
         _count++;
         _version++;
         return true;
@@ -651,17 +656,24 @@ public class CelerityDictionary<TKey, TValue, THasher>
     // bump _count) or already held the same key (false → overwrite). Hoisting
     // that signal out of the probe lets the indexer setter and TryAdd skip a
     // redundant `_keys[index]` re-read + comparer dispatch on the insert path.
+    //
+    // The probe walks `_keys` via `Unsafe.Add` against a single base reference
+    // grabbed at the top, so per-iteration bounds checks disappear. The
+    // bound is structural: `mask = keys.Length - 1` and `index = ... & mask`
+    // keep `index ∈ [0, keys.Length)` for every iteration. `(nint)(uint)index`
+    // gives the JIT the additional hint that `index` is non-negative.
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private int ProbeForInsert(TKey key, out bool wasEmpty)
     {
         TKey?[] keys = _keys;
+        ref TKey? keysRef = ref MemoryMarshal.GetArrayDataReference(keys);
         int mask = keys.Length - 1;
         var comparer = EqualityComparer<TKey>.Default;
         int index = _hasher.Hash(key) & mask;
 
         while (true)
         {
-            TKey? slot = keys[index];
+            TKey? slot = Unsafe.Add(ref keysRef, (nint)(uint)index);
             if (comparer.Equals(slot, default(TKey))) { wasEmpty = true; return index; }
             if (comparer.Equals(slot, key)) { wasEmpty = false; return index; }
             index = (index + 1) & mask;
@@ -671,17 +683,19 @@ public class CelerityDictionary<TKey, TValue, THasher>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private int ProbeForKey(TKey key)
     {
-        int size = _keys.Length;
-        int index = _hasher.Hash(key) & (size - 1);
+        TKey?[] keys = _keys;
+        ref TKey? keysRef = ref MemoryMarshal.GetArrayDataReference(keys);
+        int mask = keys.Length - 1;
+        var comparer = EqualityComparer<TKey>.Default;
+        int index = _hasher.Hash(key) & mask;
 
-        while (!EqualityComparer<TKey>.Default.Equals(_keys[index], default(TKey)))
+        while (true)
         {
-            if (EqualityComparer<TKey>.Default.Equals(_keys[index], key))
-                return index;
-            index = (index + 1) & (size - 1);
+            TKey? slot = Unsafe.Add(ref keysRef, (nint)(uint)index);
+            if (comparer.Equals(slot, default(TKey))) return -1;
+            if (comparer.Equals(slot, key)) return index;
+            index = (index + 1) & mask;
         }
-
-        return -1;
     }
 
     private void Resize()
@@ -733,6 +747,8 @@ public class CelerityDictionary<TKey, TValue, THasher>
     {
         TKey?[] keys = _keys;
         TValue?[] values = _values;
+        ref TKey? keysRef = ref MemoryMarshal.GetArrayDataReference(keys);
+        ref TValue? valuesRef = ref MemoryMarshal.GetArrayDataReference(values);
         int mask = keys.Length - 1;
         var comparer = EqualityComparer<TKey>.Default;
         int i = startIndex;
@@ -741,7 +757,7 @@ public class CelerityDictionary<TKey, TValue, THasher>
         while (true)
         {
             j = (j + 1) & mask;
-            TKey? candidateKey = keys[j];
+            TKey? candidateKey = Unsafe.Add(ref keysRef, (nint)(uint)j);
             if (comparer.Equals(candidateKey, default(TKey)))
                 break;
 
@@ -759,12 +775,12 @@ public class CelerityDictionary<TKey, TValue, THasher>
             if (bypassesGap)
                 continue;
 
-            keys[i] = candidateKey;
-            values[i] = values[j];
+            Unsafe.Add(ref keysRef, (nint)(uint)i) = candidateKey;
+            Unsafe.Add(ref valuesRef, (nint)(uint)i) = Unsafe.Add(ref valuesRef, (nint)(uint)j);
             i = j;
         }
 
-        keys[i] = default;
-        values[i] = default;
+        Unsafe.Add(ref keysRef, (nint)(uint)i) = default;
+        Unsafe.Add(ref valuesRef, (nint)(uint)i) = default;
     }
 }

--- a/src/Celerity/Collections/CeleritySet.cs
+++ b/src/Celerity/Collections/CeleritySet.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using Celerity.Hashing;
 
 namespace Celerity.Collections;
@@ -160,26 +161,32 @@ public class CeleritySet<T, THasher> : IEnumerable<T> where THasher : struct, IH
         // duplicate check so a duplicate-at-threshold call cannot silently
         // swap out the backing array under an active enumerator (see
         // issue #92).
-        int size = _slots.Length;
-        int index = _hasher.Hash(item) & (size - 1);
+        T?[] slots = _slots;
+        ref T? slotsRef = ref MemoryMarshal.GetArrayDataReference(slots);
+        int mask = slots.Length - 1;
+        var comparer = EqualityComparer<T>.Default;
+        int index = _hasher.Hash(item) & mask;
 
-        while (!EqualityComparer<T>.Default.Equals(_slots[index], default(T)))
+        while (true)
         {
-            if (EqualityComparer<T>.Default.Equals(_slots[index], item))
-                return false;
-            index = (index + 1) & (size - 1);
+            T? slot = Unsafe.Add(ref slotsRef, (nint)(uint)index);
+            if (comparer.Equals(slot, default(T))) break;
+            if (comparer.Equals(slot, item)) return false;
+            index = (index + 1) & mask;
         }
 
         if (_count >= _threshold)
         {
             Resize();
-            size = _slots.Length;
-            index = _hasher.Hash(item) & (size - 1);
-            while (!EqualityComparer<T>.Default.Equals(_slots[index], default(T)))
-                index = (index + 1) & (size - 1);
+            slots = _slots;
+            slotsRef = ref MemoryMarshal.GetArrayDataReference(slots);
+            mask = slots.Length - 1;
+            index = _hasher.Hash(item) & mask;
+            while (!comparer.Equals(Unsafe.Add(ref slotsRef, (nint)(uint)index), default(T)))
+                index = (index + 1) & mask;
         }
 
-        _slots[index] = item;
+        Unsafe.Add(ref slotsRef, (nint)(uint)index) = item;
         _count++;
         _version++;
         return true;
@@ -367,17 +374,19 @@ public class CeleritySet<T, THasher> : IEnumerable<T> where THasher : struct, IH
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private int ProbeForItem(T item)
     {
-        int size = _slots.Length;
-        int index = _hasher.Hash(item) & (size - 1);
+        T?[] slots = _slots;
+        ref T? slotsRef = ref MemoryMarshal.GetArrayDataReference(slots);
+        int mask = slots.Length - 1;
+        var comparer = EqualityComparer<T>.Default;
+        int index = _hasher.Hash(item) & mask;
 
-        while (!EqualityComparer<T>.Default.Equals(_slots[index], default(T)))
+        while (true)
         {
-            if (EqualityComparer<T>.Default.Equals(_slots[index], item))
-                return index;
-            index = (index + 1) & (size - 1);
+            T? slot = Unsafe.Add(ref slotsRef, (nint)(uint)index);
+            if (comparer.Equals(slot, default(T))) return -1;
+            if (comparer.Equals(slot, item)) return index;
+            index = (index + 1) & mask;
         }
-
-        return -1;
     }
 
     private void Resize()
@@ -425,6 +434,7 @@ public class CeleritySet<T, THasher> : IEnumerable<T> where THasher : struct, IH
     private void BackwardShiftRemove(int startIndex)
     {
         T?[] slots = _slots;
+        ref T? slotsRef = ref MemoryMarshal.GetArrayDataReference(slots);
         int mask = slots.Length - 1;
         var comparer = EqualityComparer<T>.Default;
         int i = startIndex;
@@ -433,7 +443,7 @@ public class CeleritySet<T, THasher> : IEnumerable<T> where THasher : struct, IH
         while (true)
         {
             j = (j + 1) & mask;
-            T? candidate = slots[j];
+            T? candidate = Unsafe.Add(ref slotsRef, (nint)(uint)j);
             if (comparer.Equals(candidate, default(T)))
                 break;
 
@@ -451,10 +461,10 @@ public class CeleritySet<T, THasher> : IEnumerable<T> where THasher : struct, IH
             if (bypassesGap)
                 continue;
 
-            slots[i] = candidate;
+            Unsafe.Add(ref slotsRef, (nint)(uint)i) = candidate;
             i = j;
         }
 
-        slots[i] = default;
+        Unsafe.Add(ref slotsRef, (nint)(uint)i) = default;
     }
 }

--- a/src/Celerity/Collections/CeleritySet.cs
+++ b/src/Celerity/Collections/CeleritySet.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using System.Runtime.CompilerServices;
 using Celerity.Hashing;
 
 namespace Celerity.Collections;
@@ -363,6 +364,7 @@ public class CeleritySet<T, THasher> : IEnumerable<T> where THasher : struct, IH
     private static bool IsDefaultValue(T item) =>
         EqualityComparer<T>.Default.Equals(item, default(T));
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private int ProbeForItem(T item)
     {
         int size = _slots.Length;
@@ -419,6 +421,7 @@ public class CeleritySet<T, THasher> : IEnumerable<T> where THasher : struct, IH
     // entry is visited exactly once and most are not moved at all — the
     // work-per-cluster collapses from quadratic to linear, which is the
     // bulk of the Remove speedup.
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void BackwardShiftRemove(int startIndex)
     {
         T?[] slots = _slots;

--- a/src/Celerity/Collections/IntDictionary.cs
+++ b/src/Celerity/Collections/IntDictionary.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using System.Runtime.CompilerServices;
 using Celerity.Hashing;
 
 namespace Celerity.Collections;
@@ -694,6 +695,7 @@ public class IntDictionary<TValue, THasher>
 
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private int ProbeForInsert(int key)
     {
         int size = _keys.Length;
@@ -709,6 +711,7 @@ public class IntDictionary<TValue, THasher>
         return index;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private int ProbeForKey(int key)
     {
         int size = _keys.Length;
@@ -769,6 +772,7 @@ public class IntDictionary<TValue, THasher>
     // surviving cluster entry is visited exactly once and most are not
     // moved at all — the work-per-cluster collapses from quadratic to
     // linear, which is the bulk of the Remove speedup.
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void BackwardShiftRemove(int startIndex)
     {
         int[] keys = _keys;

--- a/src/Celerity/Collections/IntDictionary.cs
+++ b/src/Celerity/Collections/IntDictionary.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using Celerity.Hashing;
 
 namespace Celerity.Collections;
@@ -228,8 +229,10 @@ public class IntDictionary<TValue, THasher>
 
             int index = ProbeForInsert(key, out bool isNewEntry);
 
-            _keys[index] = key;
-            _values[index] = value;
+            int[] keys = _keys;
+            TValue?[] values = _values;
+            Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(keys), (nint)(uint)index) = key;
+            Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(values), (nint)(uint)index) = value;
 
             if (isNewEntry)
                 _count++;
@@ -424,8 +427,10 @@ public class IntDictionary<TValue, THasher>
             index = ProbeForInsert(key, out _);
         }
 
-        _keys[index] = key;
-        _values[index] = value;
+        int[] keys = _keys;
+        TValue?[] values = _values;
+        Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(keys), (nint)(uint)index) = key;
+        Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(values), (nint)(uint)index) = value;
         _count++;
         _version++;
         return true;
@@ -699,16 +704,24 @@ public class IntDictionary<TValue, THasher>
     // bump _count) or already held the same key (false → overwrite). Hoisting
     // that signal out of the probe lets the indexer setter and TryAdd skip a
     // redundant `_keys[index]` re-read on the insert path.
+    //
+    // The probe walks `_keys` via `Unsafe.Add` against a single base reference
+    // grabbed at the top, so per-iteration bounds checks disappear. The
+    // bound is structural: `mask = keys.Length - 1` and `index = ... & mask`
+    // keep `index ∈ [0, keys.Length)` for every iteration. `(nint)(uint)index`
+    // gives the JIT the additional hint that `index` is non-negative, which
+    // unlocks a zero-extending load on x64.
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private int ProbeForInsert(int key, out bool wasEmpty)
     {
         int[] keys = _keys;
+        ref int keysRef = ref MemoryMarshal.GetArrayDataReference(keys);
         int mask = keys.Length - 1;
         int index = _hasher.Hash(key) & mask;
 
         while (true)
         {
-            int slot = keys[index];
+            int slot = Unsafe.Add(ref keysRef, (nint)(uint)index);
             if (slot == EMPTY_KEY) { wasEmpty = true; return index; }
             if (slot == key) { wasEmpty = false; return index; }
             index = (index + 1) & mask;
@@ -718,19 +731,18 @@ public class IntDictionary<TValue, THasher>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private int ProbeForKey(int key)
     {
-        int size = _keys.Length;
+        int[] keys = _keys;
+        ref int keysRef = ref MemoryMarshal.GetArrayDataReference(keys);
+        int mask = keys.Length - 1;
+        int index = _hasher.Hash(key) & mask;
 
-        // Only works when size is a power of two
-        int index = _hasher.Hash(key) & (size - 1);
-
-        while (_keys[index] != EMPTY_KEY)
+        while (true)
         {
-            if (_keys[index] == key)
-                return index;
-            index = (index + 1) & (size - 1);
+            int slot = Unsafe.Add(ref keysRef, (nint)(uint)index);
+            if (slot == EMPTY_KEY) return -1;
+            if (slot == key) return index;
+            index = (index + 1) & mask;
         }
-
-        return -1;
     }
 
     private void Resize()
@@ -781,6 +793,8 @@ public class IntDictionary<TValue, THasher>
     {
         int[] keys = _keys;
         TValue?[] values = _values;
+        ref int keysRef = ref MemoryMarshal.GetArrayDataReference(keys);
+        ref TValue? valuesRef = ref MemoryMarshal.GetArrayDataReference(values);
         int mask = keys.Length - 1;
         int i = startIndex;
         int j = i;
@@ -788,7 +802,7 @@ public class IntDictionary<TValue, THasher>
         while (true)
         {
             j = (j + 1) & mask;
-            int candidateKey = keys[j];
+            int candidateKey = Unsafe.Add(ref keysRef, (nint)(uint)j);
             if (candidateKey == EMPTY_KEY)
                 break;
 
@@ -806,12 +820,12 @@ public class IntDictionary<TValue, THasher>
             if (bypassesGap)
                 continue;
 
-            keys[i] = candidateKey;
-            values[i] = values[j];
+            Unsafe.Add(ref keysRef, (nint)(uint)i) = candidateKey;
+            Unsafe.Add(ref valuesRef, (nint)(uint)i) = Unsafe.Add(ref valuesRef, (nint)(uint)j);
             i = j;
         }
 
-        keys[i] = EMPTY_KEY;
-        values[i] = EMPTY_VALUE;
+        Unsafe.Add(ref keysRef, (nint)(uint)i) = EMPTY_KEY;
+        Unsafe.Add(ref valuesRef, (nint)(uint)i) = EMPTY_VALUE;
     }
 }

--- a/src/Celerity/Collections/IntDictionary.cs
+++ b/src/Celerity/Collections/IntDictionary.cs
@@ -226,8 +226,7 @@ public class IntDictionary<TValue, THasher>
                 Resize();
             }
 
-            int index = ProbeForInsert(key);
-            bool isNewEntry = _keys[index] == EMPTY_KEY;
+            int index = ProbeForInsert(key, out bool isNewEntry);
 
             _keys[index] = key;
             _values[index] = value;
@@ -415,14 +414,14 @@ public class IntDictionary<TValue, THasher>
         // duplicate check so a duplicate-at-threshold call cannot silently
         // swap out the backing arrays under an active enumerator (see
         // issue #92).
-        int index = ProbeForInsert(key);
-        if (_keys[index] != EMPTY_KEY)
+        int index = ProbeForInsert(key, out bool wasEmpty);
+        if (!wasEmpty)
             return false;
 
         if (_count >= _threshold)
         {
             Resize();
-            index = ProbeForInsert(key);
+            index = ProbeForInsert(key, out _);
         }
 
         _keys[index] = key;
@@ -695,20 +694,25 @@ public class IntDictionary<TValue, THasher>
 
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
+    // Returns the slot the caller should write into. <paramref name="wasEmpty"/>
+    // tells the caller whether the slot was previously empty (true → new entry,
+    // bump _count) or already held the same key (false → overwrite). Hoisting
+    // that signal out of the probe lets the indexer setter and TryAdd skip a
+    // redundant `_keys[index]` re-read on the insert path.
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private int ProbeForInsert(int key)
+    private int ProbeForInsert(int key, out bool wasEmpty)
     {
-        int size = _keys.Length;
+        int[] keys = _keys;
+        int mask = keys.Length - 1;
+        int index = _hasher.Hash(key) & mask;
 
-        // Only works when size is a power of two
-        int index = _hasher.Hash(key) & (size - 1);
-
-        while (_keys[index] != EMPTY_KEY && _keys[index] != key)
+        while (true)
         {
-            index = (index + 1) & (size - 1);
+            int slot = keys[index];
+            if (slot == EMPTY_KEY) { wasEmpty = true; return index; }
+            if (slot == key) { wasEmpty = false; return index; }
+            index = (index + 1) & mask;
         }
-
-        return index;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Celerity/Collections/IntSet.cs
+++ b/src/Celerity/Collections/IntSet.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using Celerity.Hashing;
 
 namespace Celerity.Collections;
@@ -209,26 +210,31 @@ public class IntSet<THasher> : IEnumerable<int> where THasher : struct, IHashPro
         // duplicate check so a duplicate-at-threshold call cannot silently
         // swap out the backing array under an active enumerator (see
         // issue #92).
-        int size = _slots.Length;
-        int index = _hasher.Hash(item) & (size - 1);
+        int[] slots = _slots;
+        ref int slotsRef = ref MemoryMarshal.GetArrayDataReference(slots);
+        int mask = slots.Length - 1;
+        int index = _hasher.Hash(item) & mask;
 
-        while (_slots[index] != EMPTY_SLOT)
+        while (true)
         {
-            if (_slots[index] == item)
-                return false;
-            index = (index + 1) & (size - 1);
+            int slot = Unsafe.Add(ref slotsRef, (nint)(uint)index);
+            if (slot == EMPTY_SLOT) break;
+            if (slot == item) return false;
+            index = (index + 1) & mask;
         }
 
         if (_count >= _threshold)
         {
             Resize();
-            size = _slots.Length;
-            index = _hasher.Hash(item) & (size - 1);
-            while (_slots[index] != EMPTY_SLOT)
-                index = (index + 1) & (size - 1);
+            slots = _slots;
+            slotsRef = ref MemoryMarshal.GetArrayDataReference(slots);
+            mask = slots.Length - 1;
+            index = _hasher.Hash(item) & mask;
+            while (Unsafe.Add(ref slotsRef, (nint)(uint)index) != EMPTY_SLOT)
+                index = (index + 1) & mask;
         }
 
-        _slots[index] = item;
+        Unsafe.Add(ref slotsRef, (nint)(uint)index) = item;
         _count++;
         _version++;
         return true;
@@ -412,17 +418,18 @@ public class IntSet<THasher> : IEnumerable<int> where THasher : struct, IHashPro
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private int ProbeForItem(int item)
     {
-        int size = _slots.Length;
-        int index = _hasher.Hash(item) & (size - 1);
+        int[] slots = _slots;
+        ref int slotsRef = ref MemoryMarshal.GetArrayDataReference(slots);
+        int mask = slots.Length - 1;
+        int index = _hasher.Hash(item) & mask;
 
-        while (_slots[index] != EMPTY_SLOT)
+        while (true)
         {
-            if (_slots[index] == item)
-                return index;
-            index = (index + 1) & (size - 1);
+            int slot = Unsafe.Add(ref slotsRef, (nint)(uint)index);
+            if (slot == EMPTY_SLOT) return -1;
+            if (slot == item) return index;
+            index = (index + 1) & mask;
         }
-
-        return -1;
     }
 
     private void Resize()
@@ -469,6 +476,7 @@ public class IntSet<THasher> : IEnumerable<int> where THasher : struct, IHashPro
     private void BackwardShiftRemove(int startIndex)
     {
         int[] slots = _slots;
+        ref int slotsRef = ref MemoryMarshal.GetArrayDataReference(slots);
         int mask = slots.Length - 1;
         int i = startIndex;
         int j = i;
@@ -476,7 +484,7 @@ public class IntSet<THasher> : IEnumerable<int> where THasher : struct, IHashPro
         while (true)
         {
             j = (j + 1) & mask;
-            int candidate = slots[j];
+            int candidate = Unsafe.Add(ref slotsRef, (nint)(uint)j);
             if (candidate == EMPTY_SLOT)
                 break;
 
@@ -494,10 +502,10 @@ public class IntSet<THasher> : IEnumerable<int> where THasher : struct, IHashPro
             if (bypassesGap)
                 continue;
 
-            slots[i] = candidate;
+            Unsafe.Add(ref slotsRef, (nint)(uint)i) = candidate;
             i = j;
         }
 
-        slots[i] = EMPTY_SLOT;
+        Unsafe.Add(ref slotsRef, (nint)(uint)i) = EMPTY_SLOT;
     }
 }

--- a/src/Celerity/Collections/IntSet.cs
+++ b/src/Celerity/Collections/IntSet.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using System.Runtime.CompilerServices;
 using Celerity.Hashing;
 
 namespace Celerity.Collections;
@@ -408,6 +409,7 @@ public class IntSet<THasher> : IEnumerable<int> where THasher : struct, IHashPro
         public void Dispose() { }
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private int ProbeForItem(int item)
     {
         int size = _slots.Length;
@@ -463,6 +465,7 @@ public class IntSet<THasher> : IEnumerable<int> where THasher : struct, IHashPro
     // entry is visited exactly once and most are not moved at all — the
     // work-per-cluster collapses from quadratic to linear, which is the
     // bulk of the Remove speedup.
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void BackwardShiftRemove(int startIndex)
     {
         int[] slots = _slots;

--- a/src/Celerity/Collections/LongDictionary.cs
+++ b/src/Celerity/Collections/LongDictionary.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using Celerity.Hashing;
 
 namespace Celerity.Collections;
@@ -230,8 +231,10 @@ public class LongDictionary<TValue, THasher>
 
             int index = ProbeForInsert(key, out bool isNewEntry);
 
-            _keys[index] = key;
-            _values[index] = value;
+            long[] keys = _keys;
+            TValue?[] values = _values;
+            Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(keys), (nint)(uint)index) = key;
+            Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(values), (nint)(uint)index) = value;
 
             if (isNewEntry)
                 _count++;
@@ -426,8 +429,10 @@ public class LongDictionary<TValue, THasher>
             index = ProbeForInsert(key, out _);
         }
 
-        _keys[index] = key;
-        _values[index] = value;
+        long[] keys = _keys;
+        TValue?[] values = _values;
+        Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(keys), (nint)(uint)index) = key;
+        Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(values), (nint)(uint)index) = value;
         _count++;
         _version++;
         return true;
@@ -701,16 +706,23 @@ public class LongDictionary<TValue, THasher>
     // bump _count) or already held the same key (false → overwrite). Hoisting
     // that signal out of the probe lets the indexer setter and TryAdd skip a
     // redundant `_keys[index]` re-read on the insert path.
+    //
+    // The probe walks `_keys` via `Unsafe.Add` against a single base reference
+    // grabbed at the top, so per-iteration bounds checks disappear. The
+    // bound is structural: `mask = keys.Length - 1` and `index = ... & mask`
+    // keep `index ∈ [0, keys.Length)` for every iteration. `(nint)(uint)index`
+    // gives the JIT the additional hint that `index` is non-negative.
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private int ProbeForInsert(long key, out bool wasEmpty)
     {
         long[] keys = _keys;
+        ref long keysRef = ref MemoryMarshal.GetArrayDataReference(keys);
         int mask = keys.Length - 1;
         int index = _hasher.Hash(key) & mask;
 
         while (true)
         {
-            long slot = keys[index];
+            long slot = Unsafe.Add(ref keysRef, (nint)(uint)index);
             if (slot == EMPTY_KEY) { wasEmpty = true; return index; }
             if (slot == key) { wasEmpty = false; return index; }
             index = (index + 1) & mask;
@@ -720,19 +732,18 @@ public class LongDictionary<TValue, THasher>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private int ProbeForKey(long key)
     {
-        int size = _keys.Length;
+        long[] keys = _keys;
+        ref long keysRef = ref MemoryMarshal.GetArrayDataReference(keys);
+        int mask = keys.Length - 1;
+        int index = _hasher.Hash(key) & mask;
 
-        // Only works when size is a power of two
-        int index = _hasher.Hash(key) & (size - 1);
-
-        while (_keys[index] != EMPTY_KEY)
+        while (true)
         {
-            if (_keys[index] == key)
-                return index;
-            index = (index + 1) & (size - 1);
+            long slot = Unsafe.Add(ref keysRef, (nint)(uint)index);
+            if (slot == EMPTY_KEY) return -1;
+            if (slot == key) return index;
+            index = (index + 1) & mask;
         }
-
-        return -1;
     }
 
     private void Resize()
@@ -783,6 +794,8 @@ public class LongDictionary<TValue, THasher>
     {
         long[] keys = _keys;
         TValue?[] values = _values;
+        ref long keysRef = ref MemoryMarshal.GetArrayDataReference(keys);
+        ref TValue? valuesRef = ref MemoryMarshal.GetArrayDataReference(values);
         int mask = keys.Length - 1;
         int i = startIndex;
         int j = i;
@@ -790,7 +803,7 @@ public class LongDictionary<TValue, THasher>
         while (true)
         {
             j = (j + 1) & mask;
-            long candidateKey = keys[j];
+            long candidateKey = Unsafe.Add(ref keysRef, (nint)(uint)j);
             if (candidateKey == EMPTY_KEY)
                 break;
 
@@ -808,12 +821,12 @@ public class LongDictionary<TValue, THasher>
             if (bypassesGap)
                 continue;
 
-            keys[i] = candidateKey;
-            values[i] = values[j];
+            Unsafe.Add(ref keysRef, (nint)(uint)i) = candidateKey;
+            Unsafe.Add(ref valuesRef, (nint)(uint)i) = Unsafe.Add(ref valuesRef, (nint)(uint)j);
             i = j;
         }
 
-        keys[i] = EMPTY_KEY;
-        values[i] = EMPTY_VALUE;
+        Unsafe.Add(ref keysRef, (nint)(uint)i) = EMPTY_KEY;
+        Unsafe.Add(ref valuesRef, (nint)(uint)i) = EMPTY_VALUE;
     }
 }

--- a/src/Celerity/Collections/LongDictionary.cs
+++ b/src/Celerity/Collections/LongDictionary.cs
@@ -5,10 +5,12 @@ namespace Celerity.Collections;
 
 /// <summary>
 /// A high-performance dictionary keyed by <see cref="long"/>, using
-/// <see cref="Int64WangHasher"/> by default.
+/// <see cref="Int64WangNaiveHasher"/> by default. Switch to
+/// <see cref="Int64WangHasher"/> or <see cref="Int64Murmur3Hasher"/> via the
+/// generic overload when keys are adversarial or clustered.
 /// </summary>
 /// <typeparam name="TValue">The type of the stored values.</typeparam>
-public class LongDictionary<TValue> : LongDictionary<TValue, Int64WangHasher>
+public class LongDictionary<TValue> : LongDictionary<TValue, Int64WangNaiveHasher>
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="LongDictionary{TValue}"/> class

--- a/src/Celerity/Collections/LongDictionary.cs
+++ b/src/Celerity/Collections/LongDictionary.cs
@@ -228,8 +228,7 @@ public class LongDictionary<TValue, THasher>
                 Resize();
             }
 
-            int index = ProbeForInsert(key);
-            bool isNewEntry = _keys[index] == EMPTY_KEY;
+            int index = ProbeForInsert(key, out bool isNewEntry);
 
             _keys[index] = key;
             _values[index] = value;
@@ -417,14 +416,14 @@ public class LongDictionary<TValue, THasher>
         // duplicate check so a duplicate-at-threshold call cannot silently
         // swap out the backing arrays under an active enumerator (see
         // issue #92).
-        int index = ProbeForInsert(key);
-        if (_keys[index] != EMPTY_KEY)
+        int index = ProbeForInsert(key, out bool wasEmpty);
+        if (!wasEmpty)
             return false;
 
         if (_count >= _threshold)
         {
             Resize();
-            index = ProbeForInsert(key);
+            index = ProbeForInsert(key, out _);
         }
 
         _keys[index] = key;
@@ -697,20 +696,25 @@ public class LongDictionary<TValue, THasher>
 
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
+    // Returns the slot the caller should write into. <paramref name="wasEmpty"/>
+    // tells the caller whether the slot was previously empty (true → new entry,
+    // bump _count) or already held the same key (false → overwrite). Hoisting
+    // that signal out of the probe lets the indexer setter and TryAdd skip a
+    // redundant `_keys[index]` re-read on the insert path.
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private int ProbeForInsert(long key)
+    private int ProbeForInsert(long key, out bool wasEmpty)
     {
-        int size = _keys.Length;
+        long[] keys = _keys;
+        int mask = keys.Length - 1;
+        int index = _hasher.Hash(key) & mask;
 
-        // Only works when size is a power of two
-        int index = _hasher.Hash(key) & (size - 1);
-
-        while (_keys[index] != EMPTY_KEY && _keys[index] != key)
+        while (true)
         {
-            index = (index + 1) & (size - 1);
+            long slot = keys[index];
+            if (slot == EMPTY_KEY) { wasEmpty = true; return index; }
+            if (slot == key) { wasEmpty = false; return index; }
+            index = (index + 1) & mask;
         }
-
-        return index;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Celerity/Collections/LongDictionary.cs
+++ b/src/Celerity/Collections/LongDictionary.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using System.Runtime.CompilerServices;
 using Celerity.Hashing;
 
 namespace Celerity.Collections;
@@ -696,6 +697,7 @@ public class LongDictionary<TValue, THasher>
 
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private int ProbeForInsert(long key)
     {
         int size = _keys.Length;
@@ -711,6 +713,7 @@ public class LongDictionary<TValue, THasher>
         return index;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private int ProbeForKey(long key)
     {
         int size = _keys.Length;
@@ -771,6 +774,7 @@ public class LongDictionary<TValue, THasher>
     // surviving cluster entry is visited exactly once and most are not
     // moved at all — the work-per-cluster collapses from quadratic to
     // linear, which is the bulk of the Remove speedup.
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void BackwardShiftRemove(int startIndex)
     {
         long[] keys = _keys;

--- a/src/Celerity/Collections/LongSet.cs
+++ b/src/Celerity/Collections/LongSet.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using Celerity.Hashing;
 
 namespace Celerity.Collections;
@@ -211,26 +212,31 @@ public class LongSet<THasher> : IEnumerable<long> where THasher : struct, IHashP
         // duplicate check so a duplicate-at-threshold call cannot silently
         // swap out the backing array under an active enumerator (see
         // issue #92).
-        int size = _slots.Length;
-        int index = _hasher.Hash(item) & (size - 1);
+        long[] slots = _slots;
+        ref long slotsRef = ref MemoryMarshal.GetArrayDataReference(slots);
+        int mask = slots.Length - 1;
+        int index = _hasher.Hash(item) & mask;
 
-        while (_slots[index] != EMPTY_SLOT)
+        while (true)
         {
-            if (_slots[index] == item)
-                return false;
-            index = (index + 1) & (size - 1);
+            long slot = Unsafe.Add(ref slotsRef, (nint)(uint)index);
+            if (slot == EMPTY_SLOT) break;
+            if (slot == item) return false;
+            index = (index + 1) & mask;
         }
 
         if (_count >= _threshold)
         {
             Resize();
-            size = _slots.Length;
-            index = _hasher.Hash(item) & (size - 1);
-            while (_slots[index] != EMPTY_SLOT)
-                index = (index + 1) & (size - 1);
+            slots = _slots;
+            slotsRef = ref MemoryMarshal.GetArrayDataReference(slots);
+            mask = slots.Length - 1;
+            index = _hasher.Hash(item) & mask;
+            while (Unsafe.Add(ref slotsRef, (nint)(uint)index) != EMPTY_SLOT)
+                index = (index + 1) & mask;
         }
 
-        _slots[index] = item;
+        Unsafe.Add(ref slotsRef, (nint)(uint)index) = item;
         _count++;
         _version++;
         return true;
@@ -414,17 +420,18 @@ public class LongSet<THasher> : IEnumerable<long> where THasher : struct, IHashP
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private int ProbeForItem(long item)
     {
-        int size = _slots.Length;
-        int index = _hasher.Hash(item) & (size - 1);
+        long[] slots = _slots;
+        ref long slotsRef = ref MemoryMarshal.GetArrayDataReference(slots);
+        int mask = slots.Length - 1;
+        int index = _hasher.Hash(item) & mask;
 
-        while (_slots[index] != EMPTY_SLOT)
+        while (true)
         {
-            if (_slots[index] == item)
-                return index;
-            index = (index + 1) & (size - 1);
+            long slot = Unsafe.Add(ref slotsRef, (nint)(uint)index);
+            if (slot == EMPTY_SLOT) return -1;
+            if (slot == item) return index;
+            index = (index + 1) & mask;
         }
-
-        return -1;
     }
 
     private void Resize()
@@ -471,6 +478,7 @@ public class LongSet<THasher> : IEnumerable<long> where THasher : struct, IHashP
     private void BackwardShiftRemove(int startIndex)
     {
         long[] slots = _slots;
+        ref long slotsRef = ref MemoryMarshal.GetArrayDataReference(slots);
         int mask = slots.Length - 1;
         int i = startIndex;
         int j = i;
@@ -478,7 +486,7 @@ public class LongSet<THasher> : IEnumerable<long> where THasher : struct, IHashP
         while (true)
         {
             j = (j + 1) & mask;
-            long candidate = slots[j];
+            long candidate = Unsafe.Add(ref slotsRef, (nint)(uint)j);
             if (candidate == EMPTY_SLOT)
                 break;
 
@@ -496,10 +504,10 @@ public class LongSet<THasher> : IEnumerable<long> where THasher : struct, IHashP
             if (bypassesGap)
                 continue;
 
-            slots[i] = candidate;
+            Unsafe.Add(ref slotsRef, (nint)(uint)i) = candidate;
             i = j;
         }
 
-        slots[i] = EMPTY_SLOT;
+        Unsafe.Add(ref slotsRef, (nint)(uint)i) = EMPTY_SLOT;
     }
 }

--- a/src/Celerity/Collections/LongSet.cs
+++ b/src/Celerity/Collections/LongSet.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using System.Runtime.CompilerServices;
 using Celerity.Hashing;
 
 namespace Celerity.Collections;
@@ -410,6 +411,7 @@ public class LongSet<THasher> : IEnumerable<long> where THasher : struct, IHashP
         public void Dispose() { }
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private int ProbeForItem(long item)
     {
         int size = _slots.Length;
@@ -465,6 +467,7 @@ public class LongSet<THasher> : IEnumerable<long> where THasher : struct, IHashP
     // entry is visited exactly once and most are not moved at all — the
     // work-per-cluster collapses from quadratic to linear, which is the
     // bulk of the Remove speedup.
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void BackwardShiftRemove(int startIndex)
     {
         long[] slots = _slots;

--- a/src/Celerity/Collections/LongSet.cs
+++ b/src/Celerity/Collections/LongSet.cs
@@ -5,9 +5,11 @@ namespace Celerity.Collections;
 
 /// <summary>
 /// A high-performance set of <see cref="long"/> values, using
-/// <see cref="Int64WangHasher"/> by default.
+/// <see cref="Int64WangNaiveHasher"/> by default. Switch to
+/// <see cref="Int64WangHasher"/> or <see cref="Int64Murmur3Hasher"/> via the
+/// generic overload when elements are adversarial or clustered.
 /// </summary>
-public class LongSet : LongSet<Int64WangHasher>
+public class LongSet : LongSet<Int64WangNaiveHasher>
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="LongSet"/> class

--- a/src/Celerity/Hashing/Int64WangHasher.cs
+++ b/src/Celerity/Hashing/Int64WangHasher.cs
@@ -3,15 +3,18 @@ using System.Runtime.CompilerServices;
 namespace Celerity.Hashing;
 
 /// <summary>
-/// A fast hash provider for <see cref="long"/> keys using the Thomas Wang
+/// A hash provider for <see cref="long"/> keys using the Thomas Wang
 /// 64-bit integer hash function.
 /// </summary>
 /// <remarks>
-/// This is the <see cref="long"/> counterpart to <see cref="Int32WangNaiveHasher"/>:
-/// a non-cryptographic, invertible bit-mixer that is faster than a full Murmur3
-/// finalizer. It provides better avalanche than a simple XOR-fold while remaining
-/// cheaper than <see cref="Int64Murmur3Hasher"/>. Prefer it when throughput
-/// matters more than collision resistance on adversarial inputs.
+/// A non-cryptographic, invertible bit-mixer that provides excellent avalanche
+/// for adversarially or heavily-clustered keys. The full mixer is roughly 5x
+/// the per-call cost of <see cref="Int64WangNaiveHasher"/> (the default for
+/// <see cref="Celerity.Collections.LongDictionary{TValue}"/> and
+/// <see cref="Celerity.Collections.LongSet"/>), so switch to this hasher only
+/// when profiling shows the lighter mixer is producing measurable clustering.
+/// It still sits below <see cref="Int64Murmur3Hasher"/> on the
+/// cost-vs-avalanche curve.
 /// <para>
 /// Unlike the Murmur3 finalizer, this function does <em>not</em> map
 /// <c>0</c> to <c>0</c>. If your keys are heavily concentrated around zero,

--- a/src/Celerity/Hashing/Int64WangNaiveHasher.cs
+++ b/src/Celerity/Hashing/Int64WangNaiveHasher.cs
@@ -1,0 +1,28 @@
+using System.Runtime.CompilerServices;
+
+namespace Celerity.Hashing;
+
+/// <summary>
+/// A fast hash provider for <see cref="long"/> keys that folds the upper
+/// 32 bits and the middle 16 bits of the key into the low half via XOR.
+/// </summary>
+/// <remarks>
+/// This is the 64-bit counterpart to <see cref="Int32WangNaiveHasher"/>: an
+/// extremely cheap XOR-fold with modest avalanche but very low latency. The
+/// extra <c>(int)(key &gt;&gt;&gt; 16)</c> fold over a naive <c>key.GetHashCode()</c>
+/// keeps a chunk of the high-half entropy in the result, which materially
+/// improves distribution on keys whose low 32 bits are sequential (e.g.
+/// monotonically allocated IDs with upper bits carrying type / shard).
+/// <para>
+/// Prefer it when the key distribution is already reasonably uniform and
+/// latency matters more than collision resistance. For adversarial or
+/// heavily clustered keys, switch to <see cref="Int64WangHasher"/> (full
+/// Thomas-Wang finalizer) or <see cref="Int64Murmur3Hasher"/>.
+/// </para>
+/// </remarks>
+public struct Int64WangNaiveHasher : IHashProvider<long>
+{
+    /// <inheritdoc/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public int Hash(long key) => (int)key ^ (int)((ulong)key >> 32) ^ (int)((ulong)key >> 16);
+}


### PR DESCRIPTION
**Stacked on #103.** Pick your base accordingly when reviewing.

## Summary

Four mechanically-separable layers, each in its own commit, that go after every remaining red Cel/BCL ratio after PR #103's backward-shift Remove fix.

1. **`Int64WangNaiveHasher`** ([commit](../../commit/30bbc6e)). New hasher, modeled on `Int32WangNaiveHasher` — `(int)key ^ (int)(key >> 32) ^ (int)(key >> 16)` (2 ops vs the 11-op Thomas-Wang finalizer). Swapped in as the default for `LongDictionary<TValue>` and `LongSet`. The full Wang hasher remains a one-token opt-in (`LongDictionary<TValue, Int64WangHasher>`) for adversarial keys. Targets the 1.62×, 1.48×, 1.29× losses on the Long* family.

2. **`AggressiveInlining`** on every `Probe*` and `BackwardShiftRemove` ([commit](../../commit/9d7eb4d)). The audit found none of them carried it — the hashers already do, but their callers didn't. Adding the attribute lets the JIT collapse the (probe → hash → mask → compare) pipeline into the caller stack frame.

3. **Drop redundant `_keys[index]` re-read** ([commit](../../commit/4a1050e)). The dictionary indexer setter and `TryAdd` both re-read the slot `ProbeForInsert` just touched, just to decide between new-entry and overwrite. Refactor `ProbeForInsert` to return `out bool wasEmpty` instead. Saves one bounds-checked load per insert (plus one `EqualityComparer<TKey>.Default` dispatch on `CelerityDictionary`).

4. **`Unsafe.Add` + `MemoryMarshal.GetArrayDataReference`** on probe + shift hot paths ([commit](../../commit/082ea1c)). BCL Dictionary uses this pattern aggressively; Celerity had zero `Unsafe` usage. The safety invariant `index ∈ [0, _keys.Length)` is structural (`mask = _keys.Length - 1`, `index = ... & mask`), so the bounds check is provably redundant. `(nint)(uint)index` gives the JIT the non-negative hint for the tightest emit. The wrap-around regression tests added in #103 plus the constant-hasher collision suites stress the probe boundary cyclically and would fault on any off-by-one.

## Why

Post-#103 Cel/BCL ratios still had a lot of red, with three distinct cluster patterns:

- **All Long* operations**: lost 1.19-1.62× — heavier hasher dominated.
- **Insert at 100k**: dictionaries lost 1.20-1.62× — bounds checks + redundant re-reads on every probe step.
- **Set Remove(1k)**: set-side losses up to 4.96× — per-call constant overhead from function boundaries.

Layers 1 + 2 + 3 + 4 each independently target a different cluster. The expected combined impact brings most red ratios under 1.0×; the most stubborn (set Remove at 1k) may need an architectural follow-up (Robin Hood, #63 / SoA revisit, #65), but should still drop substantially.

## Test plan

- [x] `dotnet test src/Celerity.Tests` — **746/746 passing** locally.
- [x] New `Int64WangNaiveHasherTests` (9 facts) covering formula-as-spec inputs, determinism, high-bit influence, mid-bit influence (regression guard against future "just XOR hi/lo halves" rewrites), small-input distinctness, single-high-bit-strided distinctness, and integration smoke for both `LongDictionary` and `LongSet` (now using the new default).
- [x] New `LongDictionary_Add_ThenIndexerOverwrite_ShouldSucceed` mirroring the existing IntDictionary / CelerityDictionary regression tests for the new `out bool wasEmpty` signal.
- [x] New `Dictionaries_RepeatedIndexerOverwrite_ShouldKeepCountStable` cross-dictionary stress: 100 rounds × 32 keys of overwrite, asserts `Count` never drifts past the insert count — catches a wrong-branch wire-up in `wasEmpty` that would only show under aggregate workloads.
- [x] Existing collision suites (`ConstantIntHasher` / `ConstantLongHasher` long-chain stress, `ResizeThenRemoveSweep_*_UnderFullCollision`, the wrap-around `Remove_WrapAroundCluster_*` tests added in #103) all still pass — they're the spec for the cyclic comparison in `BackwardShiftRemove` and would fault loudly on any Unsafe off-by-one.
- [ ] CI benchmarks against `gh-pages` baseline — the PR-comment workflow will diff each Cel benchmark against the current `8293ef0`/`416a7c9` numbers. Expected: most red rows drop below 1.0×; the Long* family should drop hardest; Lookup numbers must stay flat or improve.

## Risk and rollback

Each commit is independently revertable if a particular layer turns out to regress something unexpected:

- Layer 4 (Unsafe) is the riskiest and the last commit, so reverting it is one revert.
- Layer 3 (out-bool refactor) is mostly mechanical; rollback restores the re-read but doesn't change behaviour.
- Layer 2 (AggressiveInlining) is metadata-only — pure rollback, zero behavioural effect.
- Layer 1 (hasher default) is the only one that's technically observable: anyone who relies on `LongDictionary<TValue>`'s default hasher for adversarial-key mitigation needs to opt back into `Int64WangHasher` explicitly. The XML doc on both classes points at the opt-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)