### PR TITLE
ci: same-runner A/B benchmark comparison (fix false regressions)

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -124,7 +124,6 @@ jobs:
             const rows = [];
             let regressions = 0;
             let improvements = 0;
-            let compared = 0;
 
             for (const b of pr.Benchmarks) {
               const name = b.FullName;
@@ -133,7 +132,6 @@ jobs:
               const baseStats = baseMap.get(name);
               let deltaCell = '🆕 new';
               if (baseStats) {
-                compared++;
                 const baseMean = baseStats.Mean;
                 const baseStdDev = baseStats.StandardDeviation;
                 const ratio = prMean / baseMean;
@@ -159,11 +157,11 @@ jobs:
             if (regressions > 0) {
               subtitle = `${regressions} regression${regressions === 1 ? '' : 's'} ⚠️ vs main` +
                 (improvements > 0 ? `, ${improvements} improvement${improvements === 1 ? '' : 's'} ✅` : '') +
-                ` (rows past ±${thresholdPct}% beyond noise). ${compared}/${pr.Benchmarks.length} benchmarks compared.`;
+                ` (rows past ±${thresholdPct}% beyond noise).`;
             } else if (improvements > 0) {
-              subtitle = `No regressions — ${improvements} improvement${improvements === 1 ? '' : 's'} ✅ vs main. ${compared}/${pr.Benchmarks.length} benchmarks compared.`;
+              subtitle = `No regressions — ${improvements} improvement${improvements === 1 ? '' : 's'} ✅ vs main.`;
             } else {
-              subtitle = `No significant change vs main (all within ±${thresholdPct}% or noise). ${compared}/${pr.Benchmarks.length} benchmarks compared.`;
+              subtitle = `No significant change vs main (all within ±${thresholdPct}% or noise).`;
             }
 
             const baseSha = (process.env.BASE_SHA || '').slice(0, 7);

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -62,59 +62,57 @@ jobs:
           if-no-files-found: warn
           retention-days: 30
 
-      # ----- PR path: post a custom comment, do NOT touch gh-pages -----
+      # ----- PR path: same-runner A/B vs main, then comment -----
+      # GitHub-hosted runners vary in hardware by 20-50% run-to-run, so
+      # comparing absolute timings against a stored gh-pages baseline produces
+      # noise-dominated false positives. Instead we build and benchmark BOTH
+      # the PR head and the main tip back-to-back on THIS runner, so hardware
+      # variance cancels out and the delta reflects the code change alone.
 
-      - name: Fetch baseline from gh-pages
+      - name: Stage PR report
+        if: github.event_name == 'pull_request'
+        run: |
+          set -euo pipefail
+          cp Celerity.Benchmarks/BenchmarkDotNet.Artifacts/results/ci-report-full.json /tmp/pr-report-full.json
+          echo "PR report staged ($(wc -c < /tmp/pr-report-full.json) bytes)"
+
+      - name: Run base (main) benchmarks on the same runner
         if: github.event_name == 'pull_request'
         working-directory: ${{ github.workspace }}
         run: |
           set -euo pipefail
-          if git fetch origin gh-pages --depth=1 2>/dev/null \
-            && git show origin/gh-pages:dev/bench/data.js > /tmp/baseline-data.js 2>/dev/null; then
-            echo "Baseline fetched ($(wc -c < /tmp/baseline-data.js) bytes)"
-          else
-            echo "// no baseline" > /tmp/baseline-data.js
-            echo "No baseline available — comment will show n/a for deltas"
-          fi
+          git fetch origin main
+          BASE_SHA=$(git rev-parse origin/main)
+          echo "BASE_SHA=$BASE_SHA" >> "$GITHUB_ENV"
+          echo "Benchmarking base (main) at $BASE_SHA"
+          git worktree add /tmp/base-tree "$BASE_SHA"
+          cd /tmp/base-tree/src/Celerity.Benchmarks
+          dotnet run --configuration Release -- --ci
+          report=$(ls BenchmarkDotNet.Artifacts/results/*-report-full.json | head -n 1)
+          cp "$report" /tmp/base-report-full.json
+          echo "Base report staged: $report"
 
       - name: Post benchmark comment
         if: github.event_name == 'pull_request'
         uses: actions/github-script@v7
         env:
           ALERT_THRESHOLD_RATIO: '1.10'
-          BENCHMARK_NAME: 'Celerity Benchmarks'
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const fs = require('fs');
 
-            const reportPath = 'src/Celerity.Benchmarks/BenchmarkDotNet.Artifacts/results/ci-report-full.json';
-            const current = JSON.parse(fs.readFileSync(reportPath, 'utf8'));
+            const pr = JSON.parse(fs.readFileSync('/tmp/pr-report-full.json', 'utf8'));
+            const base = JSON.parse(fs.readFileSync('/tmp/base-report-full.json', 'utf8'));
 
-            // Parse baseline data.js (assigns to window.BENCHMARK_DATA = {...})
-            let baselineEntry = null;
-            try {
-              const raw = fs.readFileSync('/tmp/baseline-data.js', 'utf8');
-              const m = raw.match(/window\.BENCHMARK_DATA\s*=\s*(\{[\s\S]*\})\s*;?\s*$/);
-              if (m) {
-                const data = JSON.parse(m[1]);
-                const entries = data.entries && data.entries[process.env.BENCHMARK_NAME];
-                if (entries && entries.length > 0) {
-                  baselineEntry = entries[entries.length - 1];
-                }
-              }
-            } catch (e) {
-              core.info(`No baseline available: ${e.message}`);
-            }
-
-            const baselineMap = new Map();
-            if (baselineEntry) {
-              for (const b of baselineEntry.benches) {
-                baselineMap.set(b.name, b.value);
-              }
+            // Index base results by full benchmark name.
+            const baseMap = new Map();
+            for (const b of base.Benchmarks) {
+              baseMap.set(b.FullName, b.Statistics);
             }
 
             const formatNs = (ns) => {
+              if (ns == null) return 'n/a';
               if (ns < 1000) return `${ns.toFixed(1)} ns`;
               if (ns < 1_000_000) return `${(ns/1000).toFixed(2)} μs`;
               if (ns < 1_000_000_000) return `${(ns/1_000_000).toFixed(2)} ms`;
@@ -122,44 +120,54 @@ jobs:
             };
 
             const threshold = parseFloat(process.env.ALERT_THRESHOLD_RATIO);
+            const thresholdPct = ((threshold - 1) * 100).toFixed(0);
             const rows = [];
             let regressions = 0;
+            let improvements = 0;
             let compared = 0;
 
-            for (const b of current.Benchmarks) {
+            for (const b of pr.Benchmarks) {
               const name = b.FullName;
-              const meanNs = b.Statistics.Mean;
-              const stdDevNs = b.Statistics.StandardDeviation;
-              const baselineNs = baselineMap.get(name);
-              let deltaCell = 'n/a';
-              if (baselineNs !== undefined) {
+              const prMean = b.Statistics.Mean;
+              const prStdDev = b.Statistics.StandardDeviation;
+              const baseStats = baseMap.get(name);
+              let deltaCell = '🆕 new';
+              if (baseStats) {
                 compared++;
-                const ratio = meanNs / baselineNs;
+                const baseMean = baseStats.Mean;
+                const baseStdDev = baseStats.StandardDeviation;
+                const ratio = prMean / baseMean;
                 const pct = (ratio - 1) * 100;
                 const sign = pct >= 0 ? '+' : '';
                 deltaCell = `${sign}${pct.toFixed(1)}%`;
-                if (ratio >= threshold) {
+                // Flag only when the change clears the threshold AND exceeds the
+                // combined run-to-run noise of both measurements.
+                const beyondNoise = Math.abs(prMean - baseMean) > (prStdDev + baseStdDev);
+                if (ratio >= threshold && beyondNoise) {
                   deltaCell += ' ⚠️';
                   regressions++;
+                } else if (ratio <= (1 / threshold) && beyondNoise) {
+                  deltaCell += ' ✅';
+                  improvements++;
                 }
               }
-              rows.push(`| \`${name}\` | ${formatNs(meanNs)} | ${formatNs(stdDevNs)} | ${baselineNs !== undefined ? formatNs(baselineNs) : 'n/a'} | ${deltaCell} |`);
+              const baseMeanCell = baseStats ? formatNs(baseStats.Mean) : 'n/a';
+              rows.push(`| \`${name}\` | ${formatNs(prMean)} | ${formatNs(prStdDev)} | ${baseMeanCell} | ${deltaCell} |`);
             }
 
             let subtitle;
-            if (!baselineEntry) {
-              subtitle = 'No baseline on `gh-pages` yet — showing absolute numbers only.';
-            } else if (regressions > 0) {
-              subtitle = `${regressions} regression${regressions === 1 ? '' : 's'} vs main (⚠️ rows exceed +${((threshold - 1) * 100).toFixed(0)}%). ${compared}/${current.Benchmarks.length} benchmarks matched baseline.`;
+            if (regressions > 0) {
+              subtitle = `${regressions} regression${regressions === 1 ? '' : 's'} ⚠️ vs main` +
+                (improvements > 0 ? `, ${improvements} improvement${improvements === 1 ? '' : 's'} ✅` : '') +
+                ` (rows past ±${thresholdPct}% beyond noise). ${compared}/${pr.Benchmarks.length} benchmarks compared.`;
+            } else if (improvements > 0) {
+              subtitle = `No regressions — ${improvements} improvement${improvements === 1 ? '' : 's'} ✅ vs main. ${compared}/${pr.Benchmarks.length} benchmarks compared.`;
             } else {
-              subtitle = `All ${compared} matched benchmark${compared === 1 ? '' : 's'} within ±${((threshold - 1) * 100).toFixed(0)}% of main.`;
+              subtitle = `No significant change vs main (all within ±${thresholdPct}% or noise). ${compared}/${pr.Benchmarks.length} benchmarks compared.`;
             }
 
-            const baselineSha = baselineEntry && baselineEntry.commit && baselineEntry.commit.id
-              ? baselineEntry.commit.id.slice(0, 7)
-              : null;
-
-            const footer = `<sub>Baseline = latest entry on \`gh-pages\` \`dev/bench/data.js\`${baselineSha ? ` (commit \`${baselineSha}\`)` : ''}. Threshold: +${((threshold - 1) * 100).toFixed(0)}% mean time vs baseline.</sub>`;
+            const baseSha = (process.env.BASE_SHA || '').slice(0, 7);
+            const footer = `<sub>Same-runner A/B: main (\`${baseSha}\`) and this PR were built and benchmarked back-to-back on the same runner, so hardware variance cancels out. ⚠️ = PR mean ≥ +${thresholdPct}% slower than main and beyond combined std-dev; ✅ = correspondingly faster.</sub>`;
 
             const marker = '<!-- celerity-benchmarks-comment -->';
             const body = [
@@ -168,7 +176,7 @@ jobs:
               '',
               subtitle,
               '',
-              '| Benchmark | Mean | StdDev | Baseline (main) | Δ |',
+              '| Benchmark | This PR | StdDev | main | Δ |',
               '|---|---:|---:|---:|---:|',
               ...rows,
               '',


### PR DESCRIPTION
## Problem

On PRs, the benchmark comment was flagging ~71/72 benchmarks as regressions even when the PR didn't touch the hot path. Example from #107 (`perf(collections): Unsafe.Add BCE on enumerator MoveNext`):

> 71 regressions vs main (⚠️ rows exceed +10%). 72/72 benchmarks matched baseline.

The tell: the `System.Collections` **control** benchmarks regressed too —

| Benchmark | Δ | Touched by the PR? |
|---|---|---|
| `HashSet_Add(1000)` | +28.7% ⚠️ | No (built-in `HashSet`) |
| `Dictionary_Insert(1000)` | +20.7% ⚠️ | No (built-in `Dictionary`) |

A Celerity code change cannot slow down .NET's own `HashSet`/`Dictionary`, so these are false positives.

## Root cause

GitHub-hosted runners run on heterogeneous hardware with **±20–50% run-to-run variance**. The old PR path compared the PR's absolute timings against a baseline stored on `gh-pages` — which was measured on a *different* runner. Comparing absolute nanoseconds across two machines, with a 10% threshold, flags nearly everything. (This is why `benchmark-action`'s own default threshold is 200%.) Config mismatch was ruled out: #101 is merged and the baseline has been regenerated by the new config since (#102/#103/#105).

## Fix — same-runner A/B

On `pull_request`, build and benchmark **both** the `main` tip and the PR head **back-to-back on the same runner** (via `git worktree`), then compare those two. Hardware speed cancels out because both halves run on the identical machine, so the delta reflects the code change alone.

- A row is flagged ⚠️ only when it clears the threshold **and** the mean difference exceeds the combined std-dev of both runs (suppresses within-noise jitter on microbenchmarks).
- Significant improvements are marked ✅.
- New benchmarks (present in the PR but not main) are marked 🆕.
- The `main`-push path (publish to `gh-pages` + dashboard sync) is **unchanged** — gh-pages still feeds the historical dashboard.

## Trade-off

Each PR now runs the benchmark suite twice (main + PR), roughly doubling benchmark wall-clock. Acceptable for free OSS Actions minutes, and the alternative (noise-dominated false alarms) made the check worse than useless.

## Test plan

- [ ] Open/refresh a PR that does **not** change the hot path; confirm the control benchmarks (`HashSet_*`, `Dictionary_*`) now show ~0% Δ and no ⚠️.
- [ ] Confirm the `main` (`<sha>`) base commit is logged in the comment footer and that both runs executed on the same runner.
- [ ] Introduce a deliberate regression in one Celerity method; confirm only that row (and related ones) flags ⚠️, not the whole table.
- [ ] After merge, confirm a `main` push still publishes to `gh-pages:dev/bench/data.js` and syncs the dashboard, with no PR comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)