### PR TITLE
fix(collections): don't resize on overwrite-at-threshold (#117)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Celerity are documented here. This project follows [Keep 
 
 ## [Unreleased]
 
+### Fixed
+
+- The `this[key] = value` indexer setter on `IntDictionary<TValue, THasher>`, `LongDictionary<TValue, THasher>`, and `CelerityDictionary<TKey, TValue, THasher>` no longer calls `Resize()` when overwriting an existing key while the table is sitting at its load-factor threshold. Previously the setter ran its `if (_count >= _threshold) Resize();` check *before* probing, so a pure value overwrite — which does not grow `Count` and therefore cannot push the table over its threshold — still doubled the backing arrays and re-hashed every entry. This is the same pre-probe-`Resize` anti-pattern that #92 fixed in `TryAdd`; the fix was applied there but the parallel indexer-setter path was missed (classic drift between two code paths that should behave identically). All three setters now mirror the `TryAdd` ordering: probe first, then `Resize()` only when `isNewEntry && _count >= _threshold`, re-probing in the doubled table. An overwrite-at-threshold now issues exactly one probe walk and zero rehashing; a *new* key that reaches the threshold still grows the table as before. Pure internal change — no public API or behavioural contract change beyond "overwrite no longer resizes". Pinned by the new `IndexerOverwriteResizeTests` (one counting-hasher fact per dictionary asserting an overwrite-at-threshold issues exactly one `Hash` call — i.e. no rehash — plus per-dictionary guards that a new key at the threshold still resizes, and a 100-round repeated-overwrite stress test holding `Count` stable). Closes #117.
+
 ## [1.3.0] - 2026-05-24
 
 ### Changed

--- a/src/Celerity.Tests/Collections/IndexerOverwriteResizeTests.cs
+++ b/src/Celerity.Tests/Collections/IndexerOverwriteResizeTests.cs
@@ -1,0 +1,213 @@
+using Celerity.Collections;
+using Celerity.Hashing;
+
+namespace Celerity.Tests.Collections;
+
+/// <summary>
+/// Regression tests for issue #117: the <c>this[key] = value</c> indexer setter on
+/// <see cref="IntDictionary{TValue, THasher}"/>,
+/// <see cref="LongDictionary{TValue, THasher}"/>, and
+/// <see cref="CelerityDictionary{TKey, TValue, THasher}"/> used to run its
+/// load-factor / <c>Resize()</c> check <em>before</em> probing. When the table sat
+/// exactly at the load-factor threshold and the caller overwrote an
+/// <em>existing</em> key (a pure value update that does not grow <c>Count</c>), the
+/// setter still resized — doubling the backing arrays and re-hashing every entry —
+/// for an operation that cannot push the table over its threshold.
+///
+/// The fix mirrors the #92 <c>TryAdd</c> ordering: probe first, then resize only
+/// when <c>isNewEntry &amp;&amp; _count >= _threshold</c>, re-probing in the doubled
+/// table. These tests pin the contract by counting how many times the underlying
+/// <see cref="IHashProvider{T}"/>'s <c>Hash</c> method is called. Each probe-chain
+/// walk begins with exactly one <c>Hash</c> call (linear-probe steps don't re-hash),
+/// and <c>Resize()</c> re-hashes every surviving entry, so the hash-call count
+/// cleanly distinguishes "overwrite, no resize" (one call) from the pre-fix
+/// "overwrite triggers a full rehash" (one probe call plus one per migrated entry).
+/// </summary>
+public class IndexerOverwriteResizeTests
+{
+    private static int _hashCallCount;
+
+    private struct CountingIntHasher : IHashProvider<int>
+    {
+        public int Hash(int key)
+        {
+            _hashCallCount++;
+            unchecked
+            {
+                uint x = (uint)key;
+                x = ((x >> 16) ^ x) * 0x45d9f3b;
+                x = ((x >> 16) ^ x) * 0x45d9f3b;
+                x = (x >> 16) ^ x;
+                return (int)x;
+            }
+        }
+    }
+
+    private struct CountingLongHasher : IHashProvider<long>
+    {
+        public int Hash(long key)
+        {
+            _hashCallCount++;
+            unchecked
+            {
+                ulong x = (ulong)key;
+                x = (x ^ (x >> 30)) * 0xbf58476d1ce4e5b9UL;
+                x = (x ^ (x >> 27)) * 0x94d049bb133111ebUL;
+                x = x ^ (x >> 31);
+                return (int)x;
+            }
+        }
+    }
+
+    private struct CountingStringHasher : IHashProvider<string>
+    {
+        public int Hash(string key)
+        {
+            _hashCallCount++;
+            return key.GetHashCode();
+        }
+    }
+
+    // capacity 4 -> backing array size 4, threshold = (int)(4 * 0.75) = 3.
+    // Filling with three non-zero keys lands Count exactly on the threshold
+    // without touching the out-of-band zero / default-key slot.
+
+    [Fact]
+    public void IntDictionary_OverwriteExistingKeyAtThreshold_DoesNotResize()
+    {
+        var map = new IntDictionary<int, CountingIntHasher>(capacity: 4);
+        map[1] = 1;
+        map[2] = 2;
+        map[3] = 3;
+        Assert.Equal(3, map.Count);
+
+        _hashCallCount = 0;
+        map[2] = 99;
+
+        // Exactly one probe walk; pre-fix this was 1 (probe) + 3 (rehash) = 4.
+        Assert.Equal(1, _hashCallCount);
+        Assert.Equal(3, map.Count);
+        Assert.Equal(99, map[2]);
+        Assert.Equal(1, map[1]);
+        Assert.Equal(3, map[3]);
+    }
+
+    [Fact]
+    public void LongDictionary_OverwriteExistingKeyAtThreshold_DoesNotResize()
+    {
+        var map = new LongDictionary<int, CountingLongHasher>(capacity: 4);
+        map[1L] = 1;
+        map[2L] = 2;
+        map[3L] = 3;
+        Assert.Equal(3, map.Count);
+
+        _hashCallCount = 0;
+        map[2L] = 99;
+
+        Assert.Equal(1, _hashCallCount);
+        Assert.Equal(3, map.Count);
+        Assert.Equal(99, map[2L]);
+        Assert.Equal(1, map[1L]);
+        Assert.Equal(3, map[3L]);
+    }
+
+    [Fact]
+    public void CelerityDictionary_OverwriteExistingKeyAtThreshold_DoesNotResize()
+    {
+        var map = new CelerityDictionary<string, int, CountingStringHasher>(capacity: 4);
+        map["k1"] = 1;
+        map["k2"] = 2;
+        map["k3"] = 3;
+        Assert.Equal(3, map.Count);
+
+        _hashCallCount = 0;
+        map["k2"] = 99;
+
+        Assert.Equal(1, _hashCallCount);
+        Assert.Equal(3, map.Count);
+        Assert.Equal(99, map["k2"]);
+        Assert.Equal(1, map["k1"]);
+        Assert.Equal(3, map["k3"]);
+    }
+
+    // Complementary guard: the growth path must still fire when a *new* key
+    // pushes the table to its threshold, so the fix can't be "remove the resize".
+
+    [Fact]
+    public void IntDictionary_NewKeyAtThreshold_StillResizes()
+    {
+        var map = new IntDictionary<int, CountingIntHasher>(capacity: 4);
+        map[1] = 1;
+        map[2] = 2;
+        map[3] = 3;
+
+        _hashCallCount = 0;
+        map[4] = 4;
+
+        // A new key at the threshold resizes: one probe in the old table, a
+        // rehash of the three survivors, and one re-probe in the doubled table.
+        Assert.True(_hashCallCount > 1);
+        Assert.Equal(4, map.Count);
+        Assert.Equal(1, map[1]);
+        Assert.Equal(2, map[2]);
+        Assert.Equal(3, map[3]);
+        Assert.Equal(4, map[4]);
+    }
+
+    [Fact]
+    public void LongDictionary_NewKeyAtThreshold_StillResizes()
+    {
+        var map = new LongDictionary<int, CountingLongHasher>(capacity: 4);
+        map[1L] = 1;
+        map[2L] = 2;
+        map[3L] = 3;
+
+        _hashCallCount = 0;
+        map[4L] = 4;
+
+        Assert.True(_hashCallCount > 1);
+        Assert.Equal(4, map.Count);
+        Assert.Equal(4, map[4L]);
+    }
+
+    [Fact]
+    public void CelerityDictionary_NewKeyAtThreshold_StillResizes()
+    {
+        var map = new CelerityDictionary<string, int, CountingStringHasher>(capacity: 4);
+        map["k1"] = 1;
+        map["k2"] = 2;
+        map["k3"] = 3;
+
+        _hashCallCount = 0;
+        map["k4"] = 4;
+
+        Assert.True(_hashCallCount > 1);
+        Assert.Equal(4, map.Count);
+        Assert.Equal(4, map["k4"]);
+    }
+
+    // Behavioural guard independent of the hash counter: hammering an overwrite
+    // at the threshold many times must keep Count stable and values correct.
+    // Pre-fix, every one of these overwrites grew the backing arrays.
+
+    [Fact]
+    public void IntDictionary_RepeatedOverwriteAtThreshold_KeepsCountStable()
+    {
+        var map = new IntDictionary<int, CountingIntHasher>(capacity: 4);
+        map[1] = 1;
+        map[2] = 2;
+        map[3] = 3;
+
+        for (int round = 0; round < 100; round++)
+        {
+            map[1] = round;
+            map[2] = round + 1;
+            map[3] = round + 2;
+            Assert.Equal(3, map.Count);
+        }
+
+        Assert.Equal(99, map[1]);
+        Assert.Equal(100, map[2]);
+        Assert.Equal(101, map[3]);
+    }
+}

--- a/src/Celerity/Collections/CelerityDictionary.cs
+++ b/src/Celerity/Collections/CelerityDictionary.cs
@@ -167,12 +167,16 @@ public class CelerityDictionary<TKey, TValue, THasher>
                 return;
             }
 
-            if (_count >= _threshold)
+            // Probe before the load-factor check so a pure overwrite of an
+            // existing key never triggers a resize: only a new entry that
+            // pushes the table to its threshold grows the backing arrays
+            // (see issue #117, mirroring the #92 TryAdd ordering).
+            int index = ProbeForInsert(key, out bool isNewEntry);
+            if (isNewEntry && _count >= _threshold)
             {
                 Resize();
+                index = ProbeForInsert(key, out _);
             }
-
-            int index = ProbeForInsert(key, out bool isNewEntry);
 
             TKey?[] keys = _keys;
             TValue?[] values = _values;

--- a/src/Celerity/Collections/IntDictionary.cs
+++ b/src/Celerity/Collections/IntDictionary.cs
@@ -222,12 +222,16 @@ public class IntDictionary<TValue, THasher>
                 return;
             }
 
-            if (_count >= _threshold)
+            // Probe before the load-factor check so a pure overwrite of an
+            // existing key never triggers a resize: only a new entry that
+            // pushes the table to its threshold grows the backing arrays
+            // (see issue #117, mirroring the #92 TryAdd ordering).
+            int index = ProbeForInsert(key, out bool isNewEntry);
+            if (isNewEntry && _count >= _threshold)
             {
                 Resize();
+                index = ProbeForInsert(key, out _);
             }
-
-            int index = ProbeForInsert(key, out bool isNewEntry);
 
             int[] keys = _keys;
             TValue?[] values = _values;

--- a/src/Celerity/Collections/LongDictionary.cs
+++ b/src/Celerity/Collections/LongDictionary.cs
@@ -224,12 +224,16 @@ public class LongDictionary<TValue, THasher>
                 return;
             }
 
-            if (_count >= _threshold)
+            // Probe before the load-factor check so a pure overwrite of an
+            // existing key never triggers a resize: only a new entry that
+            // pushes the table to its threshold grows the backing arrays
+            // (see issue #117, mirroring the #92 TryAdd ordering).
+            int index = ProbeForInsert(key, out bool isNewEntry);
+            if (isNewEntry && _count >= _threshold)
             {
                 Resize();
+                index = ProbeForInsert(key, out _);
             }
-
-            int index = ProbeForInsert(key, out bool isNewEntry);
 
             long[] keys = _keys;
             TValue?[] values = _values;


### PR DESCRIPTION
## Summary

Fixes #117. The `this[key] = value` indexer setter on `IntDictionary<TValue, THasher>`, `LongDictionary<TValue, THasher>`, and `CelerityDictionary<TKey, TValue, THasher>` ran its load-factor / `Resize()` check **before** probing for the key:

```csharp
if (_count >= _threshold) Resize();
int index = ProbeForInsert(key, out bool isNewEntry);
```

When the table sat exactly at the load-factor threshold and the caller overwrote an **existing** key (a pure value update that does not grow `Count`), this still triggered a full `Resize()` — doubling the backing arrays and re-hashing every entry — for an operation that cannot push the table over its threshold.

This is the same pre-probe-`Resize` anti-pattern that #92 fixed in `TryAdd`; the fix landed there but the parallel indexer-setter path was missed (drift between two paths that should behave identically).

## What changed

- **`src/Celerity/Collections/IntDictionary.cs`, `LongDictionary.cs`, `CelerityDictionary.cs`** — all three indexer setters now mirror the #92 `TryAdd` ordering: probe first, then `Resize()` only when `isNewEntry && _count >= _threshold`, re-probing in the doubled table. An overwrite-at-threshold issues exactly one probe walk and zero rehashing; a *new* key reaching the threshold still grows the table. Sets have no indexer, so they are unaffected.
- **`src/Celerity.Tests/Collections/IndexerOverwriteResizeTests.cs`** (new) — counting-hasher regression tests: one fact per dictionary asserting an overwrite-at-threshold issues exactly one `Hash` call (pre-fix it was 1 probe + 3 rehashes = 4), per-dictionary guards that a new key at the threshold still resizes (`Hash` count > 1, all entries retained), and a 100-round repeated-overwrite stress test holding `Count` stable.
- **`CHANGELOG.md`** — `[Unreleased]` → `### Fixed` bullet.

No public API or behavioural contract change beyond "overwrite no longer resizes" — no docs / benchmark / dashboard / ROADMAP changes needed (no new public surface).

## Test plan

- [x] `dotnet build` — 0 errors locally (`net8.0`).
- [x] `dotnet test` — all **825** tests pass locally (`DOTNET_ROLL_FORWARD=Major`, `net8.0`), including the 7 new `IndexerOverwriteResizeTests`.
- [ ] CI matrix (Windows / Linux / macOS) green, including the AOT publish smoke test.
- [ ] No gh-pages dashboard refresh required — pure internal change with no new benchmark surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)