### PR TITLE
docs(collections): mention hasher escalation tier on IntDictionary/IntSet

### DIFF
--- a/src/Celerity/Collections/IntDictionary.cs
+++ b/src/Celerity/Collections/IntDictionary.cs
@@ -7,7 +7,9 @@ namespace Celerity.Collections;
 
 /// <summary>
 /// A high-performance dictionary keyed by <see cref="int"/>, using
-/// <see cref="Int32WangNaiveHasher"/> by default.
+/// <see cref="Int32WangNaiveHasher"/> by default. Switch to
+/// <see cref="Int32WangHasher"/> or <see cref="Int32Murmur3Hasher"/> via the
+/// generic overload when keys are adversarial or clustered.
 /// </summary>
 /// <typeparam name="TValue">The type of the stored values.</typeparam>
 public class IntDictionary<TValue> : IntDictionary<TValue, Int32WangNaiveHasher>

--- a/src/Celerity/Collections/IntSet.cs
+++ b/src/Celerity/Collections/IntSet.cs
@@ -7,7 +7,9 @@ namespace Celerity.Collections;
 
 /// <summary>
 /// A high-performance set of <see cref="int"/> values, using
-/// <see cref="Int32WangNaiveHasher"/> by default.
+/// <see cref="Int32WangNaiveHasher"/> by default. Switch to
+/// <see cref="Int32WangHasher"/> or <see cref="Int32Murmur3Hasher"/> via the
+/// generic overload when elements are adversarial or clustered.
 /// </summary>
 public class IntSet : IntSet<Int32WangNaiveHasher>
 {


### PR DESCRIPTION
## What

Update the XML doc summary on the `IntDictionary<TValue>` and `IntSet` convenience subclasses to mention `Int32WangHasher` and `Int32Murmur3Hasher` as the adversarial-key escalation options, mirroring what `LongDictionary<TValue>` and `LongSet` already do for the long family.

## Why

The int family shipped `Int32WangHasher` (full Thomas-Wang finalizer) and `Int32Murmur3Hasher` (Murmur3 `fmix32`) as part of the 1.3.0 release, and the choosing-a-hasher table in `docs/api/hashing.md` plus the README hasher-picking notes already cover them. The `IntDictionary<TValue>` and `IntSet` XML doc summaries did not — they only named `Int32WangNaiveHasher`. The matching long-family types call out their escalation tier inline, so a caller browsing the API in IntelliSense over `int` keys would not discover the alternatives unless they read the long-family docs.

This brings the int family to parity with the long family at the IntelliSense layer. No code or behaviour change; the XML doc tags resolve cleanly because both hashers live in the same `Celerity.Hashing` namespace already used elsewhere in the file.

## Test plan

- [x] `dotnet build` clean
- [ ] `dotnet test` (no runtime change, but worth running to confirm no surprises)