### PR TITLE
docs(roadmap): record LongSet in the 1.1.0 collections roster (#127)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -43,10 +43,11 @@ The next release rounds out the `Celerity.Collections` package with missing coll
 
 - Implement `CeleritySet<T, THasher>` — set counterpart to `CelerityDictionary`. Status: `done`.
 - Implement `LongDictionary<TValue>` — `IntDictionary` equivalent for `long` keys. Status: `done`.
+- Implement `LongSet<T>` — `IntSet` equivalent for `long` values; completes the dictionary-to-set parity (`IntDictionary` → `IntSet`, `CelerityDictionary` → `CeleritySet`, `LongDictionary` → `LongSet`). Status: `done` — shipped in v1.3.0.
 - Implement `IReadOnlyDictionary<TKey, TValue>` on `CelerityDictionary` and `IntDictionary`. Status: `done`.
 - Add `Keys` / `Values` enumerable views and `GetEnumerator()` on the dictionaries. Status: `done`.
 - Constructor accepting `IEnumerable<KeyValuePair<TKey, TValue>>`. Status: `done`.
-- Add `GetEnumerator()` and `IEnumerable<T>` conformance on the sets (`IntSet`, `CeleritySet`). Status: `done`.
+- Add `GetEnumerator()` and `IEnumerable<T>` conformance on the sets (`IntSet`, `CeleritySet`, `LongSet`). Status: `done`.
 
 ### Hashers
 


### PR DESCRIPTION
## What & why

The [2026-Q2 roadmap review (#127)](https://github.com/marius-bughiu/Celerity/issues/127) audited ROADMAP ↔ CHANGELOG ↔ issue drift and found one substantive unresolved item:

> Add `LongSet` to ROADMAP retroactively — it shipped in v1.3.0 and completed dictionary→set parity, but the 1.1.0 collections list rosters only `IntSet` / `CeleritySet`; record it under 1.1.0 (or note as parity completion) so the roster matches the shipped surface.

`LongSet` shipped in **v1.3.0** (CHANGELOG `[1.3.0]`, which explicitly notes it "Closes the last remaining dictionary-to-set parity gap"), with full dedicated tests, cross-collection shared tests, a benchmark, dashboard wiring, README, and `docs/api/collections.md` coverage — but the ROADMAP's 1.1.0 **Collections** roster was never updated to list it. This is exactly the kind of roster drift the CONTRIBUTING parity rule exists to prevent.

## Changes

- **`ROADMAP.md`** — add a dedicated `LongSet<T>` bullet to the 1.1.0 Collections roster, mirroring the existing `LongDictionary<TValue>` entry (status `done`, shipped v1.3.0, noting it completes `IntDictionary`→`IntSet`, `CelerityDictionary`→`CeleritySet`, `LongDictionary`→`LongSet` parity), and extend the sets-`GetEnumerator`/`IEnumerable<T>` bullet's roster to include `LongSet`.

Docs-only change. No source or test changes, so the build/test surface and the gh-pages benchmark dashboard are unaffected.

## Roadmap-review status (#127)

The other three audit suggestions are already resolved:

- ✅ Close #28 (cross-platform testing) — **already closed**.
- ✅ Re-scope/close #32 (Native AOT) — **already closed**.
- ⬜ **Close milestone `1.0.0`** — still open at 100% (2 closed / 0 open). This is a repo-admin action outside this PR; recommend the maintainer close it (e.g. `gh api repos/marius-bughiu/Celerity/milestones/1 -X PATCH -f state=closed`).
- ✅ This PR closes the LongSet roster drift.

Closes #127.

## Test plan

- [x] Docs-only edit; `git diff` reviewed — two lines in `ROADMAP.md`.
- [x] No `src/` changes → existing CI matrix (build + `dotnet test` across the OS matrix) and the gh-pages benchmark dashboard refresh on `main` are unaffected.
- [x] Roster now matches the shipped surface in CHANGELOG `[1.3.0]`, `README.md`, and `docs/api/collections.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)