### PR TITLE
docs: list all collections that use NextPowerOfTwo

### DIFF
--- a/docs/api/utilities.md
+++ b/docs/api/utilities.md
@@ -22,4 +22,4 @@ Returns the smallest power of two that is greater than or equal to `n`.
 - `n >= 2^30` returns `2^30` (1,073,741,824) to prevent integer overflow.
 - If `n` is already a power of two, it is returned unchanged.
 
-**Used by** `CelerityDictionary` and `IntDictionary` to round the user-supplied capacity to a power of two, which enables fast index computation via bitwise AND instead of modulo.
+**Used by** all the Celerity collections (`CelerityDictionary`, `IntDictionary`, `LongDictionary`, `CeleritySet`, `IntSet`, `LongSet`) to round the user-supplied capacity to a power of two, which enables fast index computation via bitwise AND instead of modulo.


### PR DESCRIPTION
## What

Updates the `NextPowerOfTwo` section of [`docs/api/utilities.md`](docs/api/utilities.md) so the **Used by** line names every collection that calls `FastUtils.NextPowerOfTwo`: `CelerityDictionary`, `IntDictionary`, `LongDictionary`, `CeleritySet`, `IntSet`, and `LongSet`. Previously it listed only the first two.

## Why

All six collections call `FastUtils.NextPowerOfTwo(capacity)` in their constructors to size the backing storage, but the doc named only `CelerityDictionary` and `IntDictionary` — predating the `LongDictionary` / `LongSet` / `CeleritySet` / `IntSet` additions. A reader could reasonably infer the other four size their tables differently. Pure documentation accuracy fix — no code change.

## Test plan

- [x] `dotnet build` succeeds (markdown-only change; build unaffected)
- [x] Verified each of the six collection constructors calls `FastUtils.NextPowerOfTwo`