### PR TITLE
ci(benchmarks): move PR benchmark tables below the fold

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -121,7 +121,9 @@ jobs:
 
             const threshold = parseFloat(process.env.ALERT_THRESHOLD_RATIO);
             const thresholdPct = ((threshold - 1) * 100).toFixed(0);
-            const rows = [];
+            // Each entry: { name, isHasher, prCell, stdCell, baseCell, deltaCell, flag }
+            // where flag is 'regression' | 'improvement' | null.
+            const entries = [];
             let regressions = 0;
             let improvements = 0;
 
@@ -131,6 +133,7 @@ jobs:
               const prStdDev = b.Statistics.StandardDeviation;
               const baseStats = baseMap.get(name);
               let deltaCell = '🆕 new';
+              let flag = null;
               if (baseStats) {
                 const baseMean = baseStats.Mean;
                 const baseStdDev = baseStats.StandardDeviation;
@@ -143,14 +146,26 @@ jobs:
                 const beyondNoise = Math.abs(prMean - baseMean) > (prStdDev + baseStdDev);
                 if (ratio >= threshold && beyondNoise) {
                   deltaCell += ' ⚠️';
+                  flag = 'regression';
                   regressions++;
                 } else if (ratio <= (1 / threshold) && beyondNoise) {
                   deltaCell += ' ✅';
+                  flag = 'improvement';
                   improvements++;
                 }
               }
-              const baseMeanCell = baseStats ? formatNs(baseStats.Mean) : 'n/a';
-              rows.push(`| \`${name}\` | ${formatNs(prMean)} | ${formatNs(prStdDev)} | ${baseMeanCell} | ${deltaCell} |`);
+              entries.push({
+                name,
+                // Hasher throughput benchmarks (StringHasherBenchmark,
+                // IntegerHasherBenchmark) get their own section; everything else
+                // is a collection benchmark.
+                isHasher: /Hasher/.test(name),
+                prCell: formatNs(prMean),
+                stdCell: formatNs(prStdDev),
+                baseCell: baseStats ? formatNs(baseStats.Mean) : 'n/a',
+                deltaCell,
+                flag,
+              });
             }
 
             let subtitle;
@@ -167,6 +182,38 @@ jobs:
             const baseSha = (process.env.BASE_SHA || '').slice(0, 7);
             const footer = `<sub>Same-runner A/B: main (\`${baseSha}\`) and this PR were built and benchmarked back-to-back on the same runner, so hardware variance cancels out. ⚠️ = PR mean ≥ +${thresholdPct}% slower than main and beyond combined std-dev; ✅ = correspondingly faster.</sub>`;
 
+            const header = ['| Benchmark | This PR | StdDev | main | Δ |', '|---|---:|---:|---:|---:|'];
+            const toRow = (e) => `| \`${e.name}\` | ${e.prCell} | ${e.stdCell} | ${e.baseCell} | ${e.deltaCell} |`;
+
+            // A collapsible section per benchmark family, collapsed by default so
+            // the (often large) tables stay below the fold.
+            const section = (title, list) => {
+              if (list.length === 0) return [];
+              return [
+                '<details>',
+                `<summary><b>${title}</b> (${list.length})</summary>`,
+                '',
+                ...header,
+                ...list.map(toRow),
+                '</details>',
+                '',
+              ];
+            };
+
+            // Highlights: only the flagged rows stay above the fold so reviewers
+            // see what actually moved without expanding either table.
+            const flagged = entries.filter(e => e.flag);
+            const highlights = flagged.length === 0 ? [] : [
+              '**Highlights**',
+              '',
+              ...header,
+              ...flagged.map(toRow),
+              '',
+            ];
+
+            const collections = entries.filter(e => !e.isHasher);
+            const hashers = entries.filter(e => e.isHasher);
+
             const marker = '<!-- celerity-benchmarks-comment -->';
             const body = [
               marker,
@@ -174,10 +221,9 @@ jobs:
               '',
               subtitle,
               '',
-              '| Benchmark | This PR | StdDev | main | Δ |',
-              '|---|---:|---:|---:|---:|',
-              ...rows,
-              '',
+              ...highlights,
+              ...section('Collections', collections),
+              ...section('Hashers', hashers),
               footer,
             ].join('\n');
 


### PR DESCRIPTION
## Summary

The PR benchmark comment rendered one large flat table of every benchmark, which dominated the PR view and made the description hard to scroll (#161).

This restructures the comment so the bulk stays below the fold:

- **Above the fold:** the existing summary line plus a new **Highlights** table showing *only* the flagged rows (regressions ⚠️ / improvements ✅ past ±10% beyond noise). Omitted when nothing is flagged.
- **Below the fold:** two `<details>` sections, collapsed by default — **Collections** and **Hashers** — each holding the full table for that family.

Hasher vs collection split is done by matching `/Hasher/` against the benchmark `FullName` (`StringHasherBenchmark`, `IntegerHasherBenchmark`).

## Implementation

Entirely in the `Post benchmark comment` step of `.github/workflows/benchmarks.yml`. The row accumulator was refactored from pre-formatted strings into structured `entries`, so the same data feeds the highlights, both sections, and flag filtering.

## Verification

- Ran the embedded comment-building JS against mock benchmark data; the rendered markdown matches the intended layout (highlights + two collapsed sections + footer).
- Confirmed the workflow YAML still parses.

Fixes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)
