### PR TITLE
fix(ci): publish coverage report to gh-pages (badge/report 404)

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -113,15 +113,40 @@ jobs:
           set -euo pipefail
           git fetch origin gh-pages
           git worktree add /tmp/gh-pages gh-pages
-          rm -rf /tmp/gh-pages/coverage
-          mkdir -p /tmp/gh-pages/coverage
-          cp -r coveragereport/* /tmp/gh-pages/coverage/
           cd /tmp/gh-pages
-          if git diff --quiet && git diff --cached --quiet; then
-            echo "No coverage changes to sync"
-            exit 0
+          # The benchmark workflow also pushes to gh-pages on a main push, so refresh
+          # and retry to tolerate a concurrent update. Each workflow owns a different
+          # subtree (coverage/ here, dev/ there), so re-applying on top of the latest
+          # gh-pages never clobbers the other's data.
+          published=0
+          for attempt in 1 2 3 4 5; do
+            git fetch origin gh-pages
+            git reset --hard origin/gh-pages
+            rm -rf coverage
+            mkdir -p coverage
+            cp -r "$GITHUB_WORKSPACE"/coveragereport/* coverage/
+            # Stage first, then diff the index against HEAD. The previous guard used
+            # `git diff --quiet`, which ignores *untracked* files — so on the very first
+            # run (no coverage/ committed yet) it always reported "no changes" and the
+            # report was never published. Staging first detects new files too, which
+            # both bootstraps the initial publish and stays a no-op on an unchanged rerun.
+            git -c user.name="github-actions" -c user.email="github-actions@github.com" add coverage
+            if git diff --cached --quiet; then
+              echo "No coverage changes to sync"
+              published=1
+              break
+            fi
+            git -c user.name="github-actions" -c user.email="github-actions@github.com" \
+              commit -m "Sync coverage report from ${GITHUB_SHA:0:7}"
+            if git push origin gh-pages; then
+              echo "Coverage report published."
+              published=1
+              break
+            fi
+            echo "Push rejected (attempt ${attempt}); refreshing gh-pages and retrying..."
+            sleep $((attempt * 3))
+          done
+          if [ "$published" -ne 1 ]; then
+            echo "Failed to publish coverage report after retries." >&2
+            exit 1
           fi
-          git -c user.name="github-actions" -c user.email="github-actions@github.com" add coverage
-          git -c user.name="github-actions" -c user.email="github-actions@github.com" \
-            commit -m "Sync coverage report from ${GITHUB_SHA:0:7}"
-          git push origin gh-pages


### PR DESCRIPTION
## Summary

The coverage **badge and report linked from the README 404** (`/coverage/badge.svg` and `/coverage/`). The README URLs are correct — the report was simply **never published to gh-pages**, even though the Coverage workflow reports success on every `main` push and the benchmark dashboard (`dev/bench`) publishes fine.

## Root cause

The publish step's no-op guard was:

```bash
if git diff --quiet && git diff --cached --quiet; then
  echo "No coverage changes to sync"; exit 0
fi
git add coverage
git commit ...; git push ...
```

`git diff --quiet` only inspects **tracked** files. On the first run there was no committed `coverage/` directory, so the freshly-copied report was **untracked and invisible to the guard** → it printed *"No coverage changes to sync"* and exited **before `git add` ever ran**. Since it never committed, `coverage/` stayed untracked forever, so the guard short-circuited on every subsequent run too — a permanent bootstrap failure. Confirmed in the latest run's logs (`Merge #178`): the step logged *"No coverage changes to sync"*.

## Fix

- **Stage `coverage/` before the staleness check** and diff the index against HEAD (`git diff --cached --quiet`), which detects newly-added files too. This bootstraps the first publish and remains a correct no-op when the report is unchanged.
- **Wrap the sync in a fetch-reset-retry loop** so it tolerates the benchmark workflow concurrently pushing to gh-pages on the same main push. The two own disjoint subtrees (`coverage/` vs `dev/`), so re-applying on top of the latest gh-pages never clobbers the other's data.

## Notes / test plan

- [x] `coverage.yml` parses as valid YAML; the publish script passes `bash -n`.
- [ ] **Effective after merge:** the badge/report only become live once this is on `main` and the next `main` push runs the Coverage workflow (which then commits `coverage/` to gh-pages).
- No README change required — the existing URLs are correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
