### PR TITLE
Guard BitReader cursor against 32-bit overflow

### DIFF
--- a/src/Celerity.Primitives/BitReader.cs
+++ b/src/Celerity.Primitives/BitReader.cs
@@ -102,7 +102,8 @@ public ref struct BitReader
         }
 
         long endBit = (long)_bitPosition + bitCount;
-        if (endBit > CapacityInBits)
+        // Not enough bits left, or the resulting position would overflow a 32-bit cursor: refuse without consuming.
+        if (endBit > CapacityInBits || endBit > int.MaxValue)
         {
             value = 0;
             return false;


### PR DESCRIPTION
## What

`BitReader.TryReadBits` computes `endBit = _bitPosition + bitCount` as a `long` and refuses the read when `endBit > CapacityInBits`, but never checks that `endBit` fits in the `int` cursor before assigning `_bitPosition = (int)endBit`. This adds the missing `|| endBit > int.MaxValue` term, exactly mirroring the guard `BitWriter.TryWriteBits` already carries.

## Why

`CapacityInBits` is `(long)_source.Length * 8`, so for a source span larger than ~256 MB it exceeds `int.MaxValue`. In that regime a read whose end bit passes the capacity check but exceeds `int.MaxValue` overflows `_bitPosition` to a negative value, corrupting all subsequent reads. The writer side was already hardened against this and comments on it; the reader was the asymmetric outlier. The fix is a strictly-more-restrictive guard that only ever triggers on >256 MB buffers, so it cannot affect existing behaviour.

A targeted regression test would require allocating a >256 MB buffer and reading past 2^31 bits, which is impractical for the unit suite (the writer's matching guard is likewise not unit-tested for this boundary); the change is a one-line mirror of the reviewed writer guard.

## Test plan

- [x] `dotnet build` (Celerity.Primitives) — succeeds
- [x] `dotnet test --filter ~BitBuffer` — 31/31 pass
- [ ] No behavioural change for buffers ≤ 256 MB (guard is unreachable below that size)
