### PR TITLE
Correct SwissSet drop-in-peer surface doc to ISet<T>

### DIFF
--- a/src/Celerity/Collections/SwissSet.cs
+++ b/src/Celerity/Collections/SwissSet.cs
@@ -47,7 +47,7 @@ namespace Celerity.Collections;
 /// </list>
 /// <para>
 /// It is otherwise a drop-in peer of <see cref="CeleritySet{T, THasher}"/>: same
-/// constructors, the same <see cref="IEnumerable{T}"/> surface, the same
+/// constructors, the same <see cref="ISet{T}"/> surface, the same
 /// allocation-free struct enumerator, and the same out-of-band handling of
 /// <c>default(T)</c> (so the hasher is never invoked with the zero / null element,
 /// matching the rest of the family).


### PR DESCRIPTION
## What

The `SwissSet<T, THasher>` class remarks describe it as a drop-in peer of `CeleritySet` sharing "the same `IEnumerable<T>` surface". `SwissSet` actually implements `ISet<T>` (and thus exposes `UnionWith`/`IntersectWith`/`IsSubsetOf`/etc.). This changes the cref to `ISet<T>`.

## Why

All three sibling specialized sets describe the shared surface as `ISet<T>` — `HashCachingSet` ("the same `ISet<T>` surface"), `RobinHoodSet` (same), and `PooledCeleritySet` ("the full `ISet<T>` set-algebra surface"). The type `SwissSet` claims parity with, `CeleritySet`, is itself declared `: ISet<T>`. The `IEnumerable<T>` wording is a copy-adapt slip from `SwissDictionary`'s remarks (which reference `IReadOnlyDictionary`), understating the documented surface. Doc-only, no code change.

## Test plan

- [x] `dotnet build` (Celerity) — succeeds
- [ ] `dotnet test` — not run (XML-doc-only change, no runtime effect)
