### PR TITLE
Document ArgumentOutOfRangeException on multiset/multimap source ctors

### DIFF
--- a/src/Celerity/Collections/CelerityMultiMap.cs
+++ b/src/Celerity/Collections/CelerityMultiMap.cs
@@ -131,6 +131,10 @@ public class CelerityMultiMap<TKey, TValue, THasher>
     /// <exception cref="ArgumentNullException">
     /// <paramref name="source"/> is <c>null</c>.
     /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="capacity"/> is negative, or <paramref name="loadFactor"/>
+    /// is not in the open interval (0, 1).
+    /// </exception>
     public CelerityMultiMap(
         IEnumerable<KeyValuePair<TKey, TValue>> source,
         int capacity = DEFAULT_CAPACITY,

--- a/src/Celerity/Collections/CelerityMultiSet.cs
+++ b/src/Celerity/Collections/CelerityMultiSet.cs
@@ -138,6 +138,10 @@ public class CelerityMultiSet<T, THasher> : IEnumerable<KeyValuePair<T, int>>
     /// <exception cref="ArgumentNullException">
     /// <paramref name="source"/> is <c>null</c>.
     /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="capacity"/> is negative, or <paramref name="loadFactor"/>
+    /// is not in the open interval (0, 1).
+    /// </exception>
     public CelerityMultiSet(
         IEnumerable<T> source,
         int capacity = DEFAULT_CAPACITY,


### PR DESCRIPTION
## What

The `IEnumerable` source constructors of `CelerityMultiMap` and `CelerityMultiSet` documented only `ArgumentNullException` on their XML docs. Both chain to the primary constructor (`: this(InitialCapacityForSource(source, capacity, loadFactor), loadFactor)`), which throws `ArgumentOutOfRangeException` for a negative `capacity` or a `loadFactor` outside the open interval (0, 1). This adds the missing `<exception cref="ArgumentOutOfRangeException">` tag to both.

## Why

The exception is reachable (e.g. a valid `source` with an out-of-range `loadFactor`), so the doc was incomplete. Every sibling collection with a source constructor already documents this — `BloomFilter`, `CuckooFilter`, `CountMinSketch`, `HyperLogLog`, `TopKSketch` — so this restores family consistency. Doc-only, no code change.

## Test plan

- [x] `dotnet build` (Celerity) — succeeds
- [ ] `dotnet test` — not run (XML-doc-only change, no runtime effect)
