### PR TITLE
List all documented collection types in the docs API index

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,7 +12,7 @@ This folder contains reference documentation for the Celerity high-performance c
 
 ## API reference
 
-- [Collections](api/collections.md) — `CelerityDictionary`, `IntDictionary`, `LongDictionary`, `FrozenCelerityDictionary`, `CelerityMultiMap`, `CeleritySet`, `IntSet`, `LongSet`.
+- [Collections](api/collections.md) — dictionaries (`CelerityDictionary`, `RobinHoodDictionary`, `SwissDictionary`, `HashCachingDictionary`, `PooledCelerityDictionary`, `IntDictionary`, `LongDictionary`, `SmallDictionary`, `FrozenCelerityDictionary`), sets (`CeleritySet`, `SwissSet`, `RobinHoodSet`, `HashCachingSet`, `PooledCeleritySet`, `IntSet`, `LongSet`, `FrozenCeleritySet`), multi-collections (`CelerityMultiMap`, `CelerityMultiSet`), and probabilistic / bit collections (`BitSet`, `BloomFilter`, `CuckooFilter`, `HyperLogLog`, `CountMinSketch`, `TopKSketch`).
 - [Hashing](api/hashing.md) — `IHashProvider<T>` interface and built-in hashers (`Int32WangNaiveHasher`, `Int32Murmur3Hasher`, `Int64WangHasher`, `Int64Murmur3Hasher`, `UInt32Hasher`, `UInt64Hasher`, `GuidHasher`, the `String*` hasher family, `DefaultHasher<T>`), and the `HashQualityEvaluator`.
 - [Utilities](api/utilities.md) — `FastUtils` helper methods.
 - [Native AOT & trimming](aot.md) — AOT / trim compatibility and how it is enforced.


### PR DESCRIPTION
## What

The `docs/README.md` "API reference → Collections" index line listed only 8 collection types (`CelerityDictionary`, `IntDictionary`, `LongDictionary`, `FrozenCelerityDictionary`, `CelerityMultiMap`, `CeleritySet`, `IntSet`, `LongSet`). The linked `docs/api/collections.md` actually documents ~26 types in full. This rewrites the index line to enumerate them, grouped by category (dictionaries / sets / multi-collections / probabilistic & bit collections).

## Why

Every specialized set and dictionary added since v2.0 — `SwissSet`, `RobinHoodSet`, `HashCachingSet`, `PooledCeleritySet` and their dictionary peers, plus `CelerityMultiSet`, `SmallDictionary`, and the `BitSet` / `BloomFilter` / `CuckooFilter` / `HyperLogLog` / `CountMinSketch` / `TopKSketch` probabilistic family — has a dedicated section in `collections.md` but was absent from the index that points there, so it was undiscoverable from the docs landing page. This is the classic "dictionary listed but its set counterpart isn't" drift. Doc-only.

## Test plan

- [x] Verified each listed type has a corresponding `##` section in `docs/api/collections.md`
- [ ] `dotnet build` — n/a (Markdown-only change)
