### PR TITLE
Fix "avalanced" typo in CountMinSketch remarks

### DIFF
--- a/src/Celerity/Collections/CountMinSketch.cs
+++ b/src/Celerity/Collections/CountMinSketch.cs
@@ -35,7 +35,7 @@ namespace Celerity.Collections;
 /// <para>
 /// The <c>d</c> counter columns for an element are derived from a <strong>single</strong>
 /// <see cref="IHashProvider{T}"/> call by double hashing (Kirsch–Mitzenmacher): the
-/// 32-bit base hash is avalanced into 64 bits whose two halves seed the recurrence
+/// 32-bit base hash is avalanched into 64 bits whose two halves seed the recurrence
 /// <c>g_i = h1 + i·h2</c> (the stride forced odd so the rows spread out), so adding more
 /// rows costs arithmetic, not more <see cref="IHashProvider{T}.Hash"/> calls. Because the
 /// sketch stores only counters there is no empty-slot sentinel, so unlike the hash-table


### PR DESCRIPTION
## What

Fix a spelling error in the `CountMinSketch<T, THasher>` class remarks: "avalanced" → "avalanched".

## Why

Typo in a public XML doc comment. The same term is spelled correctly in the sibling probabilistic collections (`BloomFilter`, `CuckooFilter`, `HyperLogLog`), so this restores consistency. Doc-only.

## Test plan

- [x] `dotnet build` (Celerity) — succeeds
- [ ] `dotnet test` — not run (XML-doc-only change, no runtime effect)
