### PR TITLE
fix(benchmarks): distinct keys for new set benchmarks + harden aggregate report

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -216,13 +216,33 @@ jobs:
             const entries = [];
             let regressions = 0;
             let improvements = 0;
+            let errored = 0;
 
             for (const b of pr.Benchmarks) {
               const name = b.FullName;
+              // BenchmarkDotNet emits a benchmark with null Statistics and empty
+              // Measurements when that case errored or was not run (a throwing
+              // [GlobalSetup], a cancelled shard, an OOM, ...). Surface it as a row
+              // rather than dereferencing null — one errored case must never crash
+              // the aggregate job and red-X the whole PR gate.
+              if (b.Statistics == null) {
+                errored++;
+                const baseStats = baseMap.get(name);
+                entries.push({
+                  name,
+                  isHasher: /Hasher/.test(name),
+                  prCell: '⚠️ errored',
+                  stdCell: 'n/a',
+                  baseCell: baseStats ? formatNs(baseStats.Mean) : 'n/a',
+                  deltaCell: 'no measurements',
+                  flag: null,
+                });
+                continue;
+              }
               const prMean = b.Statistics.Mean;
               const prStdDev = b.Statistics.StandardDeviation;
               const baseStats = baseMap.get(name);
-              let deltaCell = '🆕 new';
+              let deltaCell = baseMap.has(name) ? '⚠️ base errored' : '🆕 new';
               let flag = null;
               if (baseStats) {
                 const baseMean = baseStats.Mean;
@@ -267,6 +287,9 @@ jobs:
               subtitle = `No regressions — ${improvements} improvement${improvements === 1 ? '' : 's'} ✅ vs main.`;
             } else {
               subtitle = `No significant change vs main (all within ±${thresholdPct}% or noise).`;
+            }
+            if (errored > 0) {
+              subtitle += ` ⚠️ ${errored} benchmark${errored === 1 ? '' : 's'} errored (no measurements) — see the table.`;
             }
 
             const baseSha = (process.env.BASE_SHA || '').slice(0, 7);

--- a/src/Celerity.Benchmarks/HashCachingSetBenchmark.cs
+++ b/src/Celerity.Benchmarks/HashCachingSetBenchmark.cs
@@ -24,16 +24,28 @@ public class HashCachingSetBenchmark
         hashSet = new HashSet<int>(ItemCount);
         hashCachingSet = new HashCachingSet<int, Int32WangNaiveHasher>(ItemCount);
 
+        // Keys must be distinct: HashCachingSet.Add throws on a duplicate (TryAdd is
+        // the non-throwing variant), and over this halved range a random collision
+        // is near-certain at 100k by the birthday bound — which would abort the run.
+        // hashSet.Add returns false on a repeat, so it doubles as the dedup oracle:
+        // every key that reaches hashCachingSet.Add is guaranteed unique.
         Random rand = new(42);
-        for (int i = 0; i < ItemCount; i++)
+        int count = 0;
+        while (count < ItemCount)
         {
-            keys[i] = rand.Next(1, int.MaxValue / 2);
-            hashSet.Add(keys[i]);
-            hashCachingSet.Add(keys[i]);
+            int key = rand.Next(1, int.MaxValue / 2);
+            if (!hashSet.Add(key))
+            {
+                continue;
+            }
+
+            keys[count] = key;
+            hashCachingSet.Add(key);
             // A disjoint key space for the negative-lookup arm — where the cached
             // fingerprint filter lets a miss reject a slot on a single integer
             // compare instead of dereferencing every candidate element.
-            missingKeys[i] = rand.Next(int.MaxValue / 2, int.MaxValue);
+            missingKeys[count] = rand.Next(int.MaxValue / 2, int.MaxValue);
+            count++;
         }
     }
 

--- a/src/Celerity.Benchmarks/RobinHoodSetBenchmark.cs
+++ b/src/Celerity.Benchmarks/RobinHoodSetBenchmark.cs
@@ -24,16 +24,28 @@ public class RobinHoodSetBenchmark
         hashSet = new HashSet<int>(ItemCount);
         robinHoodSet = new RobinHoodSet<int, Int32WangNaiveHasher>(ItemCount);
 
+        // Keys must be distinct: RobinHoodSet.Add throws on a duplicate (TryAdd is
+        // the non-throwing variant), and over this halved range a random collision
+        // is near-certain at 100k by the birthday bound — which would abort the run.
+        // hashSet.Add returns false on a repeat, so it doubles as the dedup oracle:
+        // every key that reaches robinHoodSet.Add is guaranteed unique.
         Random rand = new(42);
-        for (int i = 0; i < ItemCount; i++)
+        int count = 0;
+        while (count < ItemCount)
         {
-            keys[i] = rand.Next(1, int.MaxValue / 2);
-            hashSet.Add(keys[i]);
-            robinHoodSet.Add(keys[i]);
+            int key = rand.Next(1, int.MaxValue / 2);
+            if (!hashSet.Add(key))
+            {
+                continue;
+            }
+
+            keys[count] = key;
+            robinHoodSet.Add(key);
             // A disjoint key space for the negative-lookup arm — where the Robin
             // Hood PSL invariant lets a miss stop early instead of scanning the
             // whole probe run.
-            missingKeys[i] = rand.Next(int.MaxValue / 2, int.MaxValue);
+            missingKeys[count] = rand.Next(int.MaxValue / 2, int.MaxValue);
+            count++;
         }
     }
 

--- a/src/Celerity.Benchmarks/SwissSetBenchmark.cs
+++ b/src/Celerity.Benchmarks/SwissSetBenchmark.cs
@@ -24,15 +24,27 @@ public class SwissSetBenchmark
         hashSet = new HashSet<int>(ItemCount);
         swissSet = new SwissSet<int, Int32WangNaiveHasher>(ItemCount);
 
+        // Keys must be distinct: SwissSet.Add throws on a duplicate (TryAdd is the
+        // non-throwing variant), and over this halved range a random collision is
+        // near-certain at 100k by the birthday bound — which would abort the run.
+        // hashSet.Add returns false on a repeat, so it doubles as the dedup oracle:
+        // every key that reaches swissSet.Add is guaranteed unique.
         Random rand = new(42);
-        for (int i = 0; i < ItemCount; i++)
+        int count = 0;
+        while (count < ItemCount)
         {
-            keys[i] = rand.Next(1, int.MaxValue / 2);
-            hashSet.Add(keys[i]);
-            swissSet.Add(keys[i]);
+            int key = rand.Next(1, int.MaxValue / 2);
+            if (!hashSet.Add(key))
+            {
+                continue;
+            }
+
+            keys[count] = key;
+            swissSet.Add(key);
             // A disjoint key space for the negative-lookup arm — SwissSet's
             // headline win, where the SIMD group scan short-circuits a miss.
-            missingKeys[i] = rand.Next(int.MaxValue / 2, int.MaxValue);
+            missingKeys[count] = rand.Next(int.MaxValue / 2, int.MaxValue);
+            count++;
         }
     }
 


### PR DESCRIPTION
## What & why

The **`aggregate & report`** benchmark check has been failing on every open PR that touches `src/**` (#246, #247, #248, #250, #255 — #249 is docs-only so it never triggers the benchmark workflow). The check dies in ~10s with:

```
TypeError: Cannot read properties of null (reading 'Mean')
##[error]Unhandled error: TypeError: Cannot read properties of null (reading 'Mean')
```

All the other checks (build-and-test, aot-publish, benchmark shards, coverage) pass — this one job is the only red X.

### Root cause (two layers)

**1. The three newest set benchmarks feed duplicate keys into throw-on-duplicate `Add()`.**

`SwissSetBenchmark`, `RobinHoodSetBenchmark`, and `HashCachingSetBenchmark` generate keys with `rand.Next(1, int.MaxValue / 2)` and hand them straight to `set.Add()`. But `Add(T)` on these sets **throws** `ArgumentException` on a duplicate (`TryAdd` is the non-throwing variant). Over that halved range a random collision is near-certain at `ItemCount=100000` by the birthday bound (~4-5 expected), so `[GlobalSetup]` throws and **every 100k case for those three classes produces no measurements** → `Statistics: null`. `ItemCount=1000` essentially never collides, which is why it only bit at scale. (`CeleritySetBenchmark` uses the *full* range and happens to dodge a collision for this PRNG seed — it's latent, not immune.)

**2. The aggregate script then dereferences the null.** The `Post benchmark comment` github-script does `b.Statistics.Mean` for every PR benchmark, so a single null-Statistics case crashes the whole job and red-Xes the gate.

### The fix

- **Distinct keys** (`SwissSet`/`RobinHood`/`HashCaching` benchmarks): `hashSet.Add`'s return value doubles as the dedup oracle, so every key handed to the specialized set's `Add` is guaranteed unique. The random distribution, the `.Add()` API under test, and the disjoint missing-key space are all preserved.
- **Harden the report script**: a benchmark with null `Statistics` (a throwing setup, a cancelled shard, an OOM) is now rendered as an `⚠️ errored` row and counted in the subtitle, instead of taking down the whole aggregate job. A single errored case must never red-X the PR gate again — this also backstops the latent case in the older benchmarks.

## Verification

- **Benchmark fix** — reproduced against the real `SwissSet<int, Int32WangNaiveHasher>` on net10: the old key-gen throws `ArgumentException: The element 357946961 already exists` (the *exact* element from the CI shard log) at 100k; the new key-gen yields **100000 distinct keys, no throw**, missing-key space disjoint. Benchmarks project builds clean (0 warnings).
- **Script fix** — extracted the exact github-script body and ran it against **the failed run's actual artifacts** (the ones containing the 24 null-Statistics benchmarks): the original throws the identical `TypeError`; the hardened version completes and reports all 24 as errored rows plus a subtitle note.

## Rollout note

This fixes the source on `main`. Because `pull_request` runs use the workflow + benchmark source from each PR's own branch, the other open PRs will go green once they merge `main` in (their base = `main` will be fixed, and their head will pick up the hardened script + distinct-key benchmarks). Happy to update those branches once this lands.
