### PR TITLE
Remove unused Snapshot.NodeIds from the hash rings

### DIFF
--- a/src/Celerity.Ring/ConsistentHashRing.cs
+++ b/src/Celerity.Ring/ConsistentHashRing.cs
@@ -331,7 +331,7 @@ public class ConsistentHashRing<TNode, TKey, THasher>
             ownerIndex[i] = (int)(uint)packed[i];
         }
 
-        _snapshot = new Snapshot(positions, ownerIndex, nodes, nodeIds);
+        _snapshot = new Snapshot(positions, ownerIndex, nodes);
     }
 
     private sealed class Registration
@@ -353,14 +353,13 @@ public class ConsistentHashRing<TNode, TKey, THasher>
     private sealed class Snapshot
     {
         internal static readonly Snapshot Empty =
-            new Snapshot(Array.Empty<uint>(), Array.Empty<int>(), Array.Empty<TNode>(), Array.Empty<string>());
+            new Snapshot(Array.Empty<uint>(), Array.Empty<int>(), Array.Empty<TNode>());
 
-        internal Snapshot(uint[] positions, int[] ownerIndex, TNode[] nodes, string[] nodeIds)
+        internal Snapshot(uint[] positions, int[] ownerIndex, TNode[] nodes)
         {
             Positions = positions;
             OwnerIndex = ownerIndex;
             Nodes = nodes;
-            NodeIds = nodeIds;
         }
 
         internal uint[] Positions { get; }
@@ -368,8 +367,6 @@ public class ConsistentHashRing<TNode, TKey, THasher>
         internal int[] OwnerIndex { get; }
 
         internal TNode[] Nodes { get; }
-
-        internal string[] NodeIds { get; }
     }
 }
 

--- a/src/Celerity.Ring/RendezvousHash.cs
+++ b/src/Celerity.Ring/RendezvousHash.cs
@@ -255,7 +255,7 @@ public class RendezvousHash<TNode, TKey, THasher>
             weights[i] = registration.Weight;
         }
 
-        _snapshot = new Snapshot(nodes, nodeIds, nodeHashes, weights);
+        _snapshot = new Snapshot(nodes, nodeHashes, weights);
     }
 
     private sealed class Registration
@@ -274,19 +274,16 @@ public class RendezvousHash<TNode, TKey, THasher>
     private sealed class Snapshot
     {
         internal static readonly Snapshot Empty =
-            new Snapshot(Array.Empty<TNode>(), Array.Empty<string>(), Array.Empty<uint>(), Array.Empty<int>());
+            new Snapshot(Array.Empty<TNode>(), Array.Empty<uint>(), Array.Empty<int>());
 
-        internal Snapshot(TNode[] nodes, string[] nodeIds, uint[] nodeHashes, int[] weights)
+        internal Snapshot(TNode[] nodes, uint[] nodeHashes, int[] weights)
         {
             Nodes = nodes;
-            NodeIds = nodeIds;
             NodeHashes = nodeHashes;
             Weights = weights;
         }
 
         internal TNode[] Nodes { get; }
-
-        internal string[] NodeIds { get; }
 
         internal uint[] NodeHashes { get; }
 


### PR DESCRIPTION
## What

Removes the `NodeIds` `string[]` property from the private, immutable `Snapshot` type inside both `ConsistentHashRing<TNode, TKey, THasher>` and `RendezvousHash<TNode, TKey, THasher>`. In both types the array was built and passed into the snapshot on every `Rebuild()` but was never read by anything — routing (`GetNode` / `TryGetNode` / `GetReplicas`) resolves nodes through `OwnerIndex` / `NodeHashes` / `Weights`, and `Snapshot` is a `private sealed` nested class with no external reader. The change drops the property, the constructor parameter and assignment, and the `Array.Empty<string>()` argument in `Snapshot.Empty`. The `nodeIds` local in `Rebuild()` is unaffected — it is still used for deterministic ordinal ordering and registry lookups.

## Why

Dead code: a per-rebuild allocation and field that carries no behaviour. Removing it trims the snapshot's footprint and removes a maintenance trap (a field that looks load-bearing but isn't). Pure cleanup — no public API surface change and no behaviour change.

## Test plan

- [x] `dotnet build` (Celerity.Ring) — succeeds, 0 warnings
- [x] `dotnet test` (Celerity.Ring.Tests) — 31/31 pass, including the determinism and golden-value tests that pin the routing contract
- [x] Confirmed via repo-wide grep that `.NodeIds` has no read site
