### PR TITLE
docs(collections): document ArgumentOutOfRangeException on hash-table capacity/loadFactor constructors (#270)

### DIFF
--- a/src/Celerity/Collections/CelerityDictionary.cs
+++ b/src/Celerity/Collections/CelerityDictionary.cs
@@ -57,6 +57,10 @@ public class CelerityDictionary<TKey, TValue, THasher>
     /// <param name="loadFactor">
     /// The fraction of the dictionary's size that can be filled before resizing.
     /// </param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="capacity"/> is negative, or <paramref name="loadFactor"/>
+    /// is not in the open interval (0, 1).
+    /// </exception>
     public CelerityDictionary(
         int capacity = DEFAULT_CAPACITY,
         float loadFactor = DEFAULT_LOAD_FACTOR)
@@ -95,6 +99,10 @@ public class CelerityDictionary<TKey, TValue, THasher>
     /// </param>
     /// <exception cref="ArgumentNullException">
     /// <paramref name="source"/> is <c>null</c>.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="capacity"/> is negative, or <paramref name="loadFactor"/>
+    /// is not in the open interval (0, 1).
     /// </exception>
     /// <exception cref="ArgumentException">
     /// <paramref name="source"/> contains one or more duplicate keys.

--- a/src/Celerity/Collections/CeleritySet.cs
+++ b/src/Celerity/Collections/CeleritySet.cs
@@ -54,6 +54,10 @@ public class CeleritySet<T, THasher> : ISet<T> where THasher : struct, IHashProv
     /// <param name="loadFactor">
     /// The fraction of the set's size that can be filled before resizing.
     /// </param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="capacity"/> is negative, or <paramref name="loadFactor"/>
+    /// is not in the open interval (0, 1).
+    /// </exception>
     public CeleritySet(
         int capacity = DEFAULT_CAPACITY,
         float loadFactor = DEFAULT_LOAD_FACTOR)
@@ -94,6 +98,10 @@ public class CeleritySet<T, THasher> : ISet<T> where THasher : struct, IHashProv
     /// </param>
     /// <exception cref="ArgumentNullException">
     /// <paramref name="source"/> is <c>null</c>.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="capacity"/> is negative, or <paramref name="loadFactor"/>
+    /// is not in the open interval (0, 1).
     /// </exception>
     public CeleritySet(
         IEnumerable<T> source,

--- a/src/Celerity/Collections/HashCachingDictionary.cs
+++ b/src/Celerity/Collections/HashCachingDictionary.cs
@@ -98,6 +98,10 @@ public class HashCachingDictionary<TKey, TValue, THasher>
     /// <param name="loadFactor">
     /// The fraction of the dictionary's size that can be filled before resizing.
     /// </param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="capacity"/> is negative, or <paramref name="loadFactor"/>
+    /// is not in the open interval (0, 1).
+    /// </exception>
     public HashCachingDictionary(
         int capacity = DEFAULT_CAPACITY,
         float loadFactor = DEFAULT_LOAD_FACTOR)
@@ -137,6 +141,10 @@ public class HashCachingDictionary<TKey, TValue, THasher>
     /// </param>
     /// <exception cref="ArgumentNullException">
     /// <paramref name="source"/> is <c>null</c>.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="capacity"/> is negative, or <paramref name="loadFactor"/>
+    /// is not in the open interval (0, 1).
     /// </exception>
     /// <exception cref="ArgumentException">
     /// <paramref name="source"/> contains one or more duplicate keys.

--- a/src/Celerity/Collections/HashCachingSet.cs
+++ b/src/Celerity/Collections/HashCachingSet.cs
@@ -98,6 +98,10 @@ public class HashCachingSet<T, THasher> : ISet<T> where THasher : struct, IHashP
     /// <param name="loadFactor">
     /// The fraction of the set's size that can be filled before resizing.
     /// </param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="capacity"/> is negative, or <paramref name="loadFactor"/>
+    /// is not in the open interval (0, 1).
+    /// </exception>
     public HashCachingSet(
         int capacity = DEFAULT_CAPACITY,
         float loadFactor = DEFAULT_LOAD_FACTOR)
@@ -139,6 +143,10 @@ public class HashCachingSet<T, THasher> : ISet<T> where THasher : struct, IHashP
     /// </param>
     /// <exception cref="ArgumentNullException">
     /// <paramref name="source"/> is <c>null</c>.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="capacity"/> is negative, or <paramref name="loadFactor"/>
+    /// is not in the open interval (0, 1).
     /// </exception>
     public HashCachingSet(
         IEnumerable<T> source,

--- a/src/Celerity/Collections/IntDictionary.cs
+++ b/src/Celerity/Collections/IntDictionary.cs
@@ -25,6 +25,10 @@ public class IntDictionary<TValue> : IntDictionary<TValue, Int32WangNaiveHasher>
     /// <param name="loadFactor">
     /// Determines the maximum ratio of count to capacity before resizing.
     /// </param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="capacity"/> is negative, or <paramref name="loadFactor"/>
+    /// is not in the open interval (0, 1).
+    /// </exception>
     public IntDictionary(int capacity = DEFAULT_CAPACITY,
         float loadFactor = DEFAULT_LOAD_FACTOR)
         : base(capacity, loadFactor)
@@ -50,6 +54,10 @@ public class IntDictionary<TValue> : IntDictionary<TValue, Int32WangNaiveHasher>
     /// </param>
     /// <exception cref="ArgumentNullException">
     /// <paramref name="source"/> is <c>null</c>.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="capacity"/> is negative, or <paramref name="loadFactor"/>
+    /// is not in the open interval (0, 1).
     /// </exception>
     /// <exception cref="ArgumentException">
     /// <paramref name="source"/> contains one or more duplicate keys.
@@ -116,6 +124,10 @@ public class IntDictionary<TValue, THasher>
     /// <param name="loadFactor">
     /// Determines the maximum ratio of count to capacity before resizing.
     /// </param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="capacity"/> is negative, or <paramref name="loadFactor"/>
+    /// is not in the open interval (0, 1).
+    /// </exception>
     public IntDictionary(
         int capacity = DEFAULT_CAPACITY,
         float loadFactor = DEFAULT_LOAD_FACTOR)
@@ -154,6 +166,10 @@ public class IntDictionary<TValue, THasher>
     /// </param>
     /// <exception cref="ArgumentNullException">
     /// <paramref name="source"/> is <c>null</c>.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="capacity"/> is negative, or <paramref name="loadFactor"/>
+    /// is not in the open interval (0, 1).
     /// </exception>
     /// <exception cref="ArgumentException">
     /// <paramref name="source"/> contains one or more duplicate keys.

--- a/src/Celerity/Collections/IntSet.cs
+++ b/src/Celerity/Collections/IntSet.cs
@@ -24,6 +24,10 @@ public class IntSet : IntSet<Int32WangNaiveHasher>
     /// <param name="loadFactor">
     /// Determines the maximum ratio of count to capacity before resizing.
     /// </param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="capacity"/> is negative, or <paramref name="loadFactor"/>
+    /// is not in the open interval (0, 1).
+    /// </exception>
     public IntSet(int capacity = DEFAULT_CAPACITY,
         float loadFactor = DEFAULT_LOAD_FACTOR)
         : base(capacity, loadFactor)
@@ -48,6 +52,10 @@ public class IntSet : IntSet<Int32WangNaiveHasher>
     /// </param>
     /// <exception cref="ArgumentNullException">
     /// <paramref name="source"/> is <c>null</c>.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="capacity"/> is negative, or <paramref name="loadFactor"/>
+    /// is not in the open interval (0, 1).
     /// </exception>
     public IntSet(
         IEnumerable<int> source,
@@ -107,6 +115,10 @@ public class IntSet<THasher> : ISet<int> where THasher : struct, IHashProvider<i
     /// <param name="loadFactor">
     /// Determines the maximum ratio of count to capacity before resizing.
     /// </param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="capacity"/> is negative, or <paramref name="loadFactor"/>
+    /// is not in the open interval (0, 1).
+    /// </exception>
     public IntSet(
         int capacity = DEFAULT_CAPACITY,
         float loadFactor = DEFAULT_LOAD_FACTOR)
@@ -145,6 +157,10 @@ public class IntSet<THasher> : ISet<int> where THasher : struct, IHashProvider<i
     /// </param>
     /// <exception cref="ArgumentNullException">
     /// <paramref name="source"/> is <c>null</c>.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="capacity"/> is negative, or <paramref name="loadFactor"/>
+    /// is not in the open interval (0, 1).
     /// </exception>
     public IntSet(
         IEnumerable<int> source,

--- a/src/Celerity/Collections/LongDictionary.cs
+++ b/src/Celerity/Collections/LongDictionary.cs
@@ -25,6 +25,10 @@ public class LongDictionary<TValue> : LongDictionary<TValue, Int64WangNaiveHashe
     /// <param name="loadFactor">
     /// Determines the maximum ratio of count to capacity before resizing.
     /// </param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="capacity"/> is negative, or <paramref name="loadFactor"/>
+    /// is not in the open interval (0, 1).
+    /// </exception>
     public LongDictionary(int capacity = DEFAULT_CAPACITY,
         float loadFactor = DEFAULT_LOAD_FACTOR)
         : base(capacity, loadFactor)
@@ -50,6 +54,10 @@ public class LongDictionary<TValue> : LongDictionary<TValue, Int64WangNaiveHashe
     /// </param>
     /// <exception cref="ArgumentNullException">
     /// <paramref name="source"/> is <c>null</c>.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="capacity"/> is negative, or <paramref name="loadFactor"/>
+    /// is not in the open interval (0, 1).
     /// </exception>
     /// <exception cref="ArgumentException">
     /// <paramref name="source"/> contains one or more duplicate keys.
@@ -116,6 +124,10 @@ public class LongDictionary<TValue, THasher>
     /// <param name="loadFactor">
     /// Determines the maximum ratio of count to capacity before resizing.
     /// </param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="capacity"/> is negative, or <paramref name="loadFactor"/>
+    /// is not in the open interval (0, 1).
+    /// </exception>
     public LongDictionary(
         int capacity = DEFAULT_CAPACITY,
         float loadFactor = DEFAULT_LOAD_FACTOR)
@@ -154,6 +166,10 @@ public class LongDictionary<TValue, THasher>
     /// </param>
     /// <exception cref="ArgumentNullException">
     /// <paramref name="source"/> is <c>null</c>.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="capacity"/> is negative, or <paramref name="loadFactor"/>
+    /// is not in the open interval (0, 1).
     /// </exception>
     /// <exception cref="ArgumentException">
     /// <paramref name="source"/> contains one or more duplicate keys.

--- a/src/Celerity/Collections/LongSet.cs
+++ b/src/Celerity/Collections/LongSet.cs
@@ -24,6 +24,10 @@ public class LongSet : LongSet<Int64WangNaiveHasher>
     /// <param name="loadFactor">
     /// Determines the maximum ratio of count to capacity before resizing.
     /// </param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="capacity"/> is negative, or <paramref name="loadFactor"/>
+    /// is not in the open interval (0, 1).
+    /// </exception>
     public LongSet(int capacity = DEFAULT_CAPACITY,
         float loadFactor = DEFAULT_LOAD_FACTOR)
         : base(capacity, loadFactor)
@@ -48,6 +52,10 @@ public class LongSet : LongSet<Int64WangNaiveHasher>
     /// </param>
     /// <exception cref="ArgumentNullException">
     /// <paramref name="source"/> is <c>null</c>.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="capacity"/> is negative, or <paramref name="loadFactor"/>
+    /// is not in the open interval (0, 1).
     /// </exception>
     public LongSet(
         IEnumerable<long> source,
@@ -107,6 +115,10 @@ public class LongSet<THasher> : ISet<long> where THasher : struct, IHashProvider
     /// <param name="loadFactor">
     /// Determines the maximum ratio of count to capacity before resizing.
     /// </param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="capacity"/> is negative, or <paramref name="loadFactor"/>
+    /// is not in the open interval (0, 1).
+    /// </exception>
     public LongSet(
         int capacity = DEFAULT_CAPACITY,
         float loadFactor = DEFAULT_LOAD_FACTOR)
@@ -145,6 +157,10 @@ public class LongSet<THasher> : ISet<long> where THasher : struct, IHashProvider
     /// </param>
     /// <exception cref="ArgumentNullException">
     /// <paramref name="source"/> is <c>null</c>.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="capacity"/> is negative, or <paramref name="loadFactor"/>
+    /// is not in the open interval (0, 1).
     /// </exception>
     public LongSet(
         IEnumerable<long> source,

--- a/src/Celerity/Collections/PooledCelerityDictionary.cs
+++ b/src/Celerity/Collections/PooledCelerityDictionary.cs
@@ -109,6 +109,10 @@ public class PooledCelerityDictionary<TKey, TValue, THasher>
     /// <param name="loadFactor">
     /// The fraction of the dictionary's size that can be filled before resizing.
     /// </param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="capacity"/> is negative, or <paramref name="loadFactor"/>
+    /// is not in the open interval (0, 1).
+    /// </exception>
     public PooledCelerityDictionary(
         int capacity = DEFAULT_CAPACITY,
         float loadFactor = DEFAULT_LOAD_FACTOR)
@@ -151,6 +155,10 @@ public class PooledCelerityDictionary<TKey, TValue, THasher>
     /// </param>
     /// <exception cref="ArgumentNullException">
     /// <paramref name="source"/> is <c>null</c>.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="capacity"/> is negative, or <paramref name="loadFactor"/>
+    /// is not in the open interval (0, 1).
     /// </exception>
     /// <exception cref="ArgumentException">
     /// <paramref name="source"/> contains one or more duplicate keys.

--- a/src/Celerity/Collections/PooledCeleritySet.cs
+++ b/src/Celerity/Collections/PooledCeleritySet.cs
@@ -104,6 +104,10 @@ public class PooledCeleritySet<T, THasher> : ISet<T>, IDisposable
     /// <param name="loadFactor">
     /// The fraction of the set's size that can be filled before resizing.
     /// </param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="capacity"/> is negative, or <paramref name="loadFactor"/>
+    /// is not in the open interval (0, 1).
+    /// </exception>
     public PooledCeleritySet(
         int capacity = DEFAULT_CAPACITY,
         float loadFactor = DEFAULT_LOAD_FACTOR)
@@ -147,6 +151,10 @@ public class PooledCeleritySet<T, THasher> : ISet<T>, IDisposable
     /// </param>
     /// <exception cref="ArgumentNullException">
     /// <paramref name="source"/> is <c>null</c>.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="capacity"/> is negative, or <paramref name="loadFactor"/>
+    /// is not in the open interval (0, 1).
     /// </exception>
     public PooledCeleritySet(
         IEnumerable<T> source,

--- a/src/Celerity/Collections/RobinHoodDictionary.cs
+++ b/src/Celerity/Collections/RobinHoodDictionary.cs
@@ -96,6 +96,10 @@ public class RobinHoodDictionary<TKey, TValue, THasher>
     /// <param name="loadFactor">
     /// The fraction of the dictionary's size that can be filled before resizing.
     /// </param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="capacity"/> is negative, or <paramref name="loadFactor"/>
+    /// is not in the open interval (0, 1).
+    /// </exception>
     public RobinHoodDictionary(
         int capacity = DEFAULT_CAPACITY,
         float loadFactor = DEFAULT_LOAD_FACTOR)
@@ -135,6 +139,10 @@ public class RobinHoodDictionary<TKey, TValue, THasher>
     /// </param>
     /// <exception cref="ArgumentNullException">
     /// <paramref name="source"/> is <c>null</c>.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="capacity"/> is negative, or <paramref name="loadFactor"/>
+    /// is not in the open interval (0, 1).
     /// </exception>
     /// <exception cref="ArgumentException">
     /// <paramref name="source"/> contains one or more duplicate keys.

--- a/src/Celerity/Collections/RobinHoodSet.cs
+++ b/src/Celerity/Collections/RobinHoodSet.cs
@@ -96,6 +96,10 @@ public class RobinHoodSet<T, THasher> : ISet<T> where THasher : struct, IHashPro
     /// <param name="loadFactor">
     /// The fraction of the set's size that can be filled before resizing.
     /// </param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="capacity"/> is negative, or <paramref name="loadFactor"/>
+    /// is not in the open interval (0, 1).
+    /// </exception>
     public RobinHoodSet(
         int capacity = DEFAULT_CAPACITY,
         float loadFactor = DEFAULT_LOAD_FACTOR)
@@ -137,6 +141,10 @@ public class RobinHoodSet<T, THasher> : ISet<T> where THasher : struct, IHashPro
     /// </param>
     /// <exception cref="ArgumentNullException">
     /// <paramref name="source"/> is <c>null</c>.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="capacity"/> is negative, or <paramref name="loadFactor"/>
+    /// is not in the open interval (0, 1).
     /// </exception>
     public RobinHoodSet(
         IEnumerable<T> source,

--- a/src/Celerity/Collections/SwissDictionary.cs
+++ b/src/Celerity/Collections/SwissDictionary.cs
@@ -123,6 +123,10 @@ public class SwissDictionary<TKey, TValue, THasher>
     /// <param name="loadFactor">
     /// The fraction of the dictionary's size that can be filled before resizing.
     /// </param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="capacity"/> is negative, or <paramref name="loadFactor"/>
+    /// is not in the open interval (0, 1).
+    /// </exception>
     public SwissDictionary(
         int capacity = DEFAULT_CAPACITY,
         float loadFactor = DEFAULT_LOAD_FACTOR)
@@ -166,6 +170,10 @@ public class SwissDictionary<TKey, TValue, THasher>
     /// </param>
     /// <exception cref="ArgumentNullException">
     /// <paramref name="source"/> is <c>null</c>.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="capacity"/> is negative, or <paramref name="loadFactor"/>
+    /// is not in the open interval (0, 1).
     /// </exception>
     /// <exception cref="ArgumentException">
     /// <paramref name="source"/> contains one or more duplicate keys.

--- a/src/Celerity/Collections/SwissSet.cs
+++ b/src/Celerity/Collections/SwissSet.cs
@@ -121,6 +121,10 @@ public class SwissSet<T, THasher> : ISet<T> where THasher : struct, IHashProvide
     /// <param name="loadFactor">
     /// The fraction of the set's size that can be filled before resizing.
     /// </param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="capacity"/> is negative, or <paramref name="loadFactor"/>
+    /// is not in the open interval (0, 1).
+    /// </exception>
     public SwissSet(
         int capacity = DEFAULT_CAPACITY,
         float loadFactor = DEFAULT_LOAD_FACTOR)
@@ -165,6 +169,10 @@ public class SwissSet<T, THasher> : ISet<T> where THasher : struct, IHashProvide
     /// </param>
     /// <exception cref="ArgumentNullException">
     /// <paramref name="source"/> is <c>null</c>.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="capacity"/> is negative, or <paramref name="loadFactor"/>
+    /// is not in the open interval (0, 1).
     /// </exception>
     public SwissSet(
         IEnumerable<T> source,


### PR DESCRIPTION
## Summary

Closes #270.

The capacity/load-factor constructors of the open-addressed hash-table family throw `ArgumentOutOfRangeException` (negative `capacity`, or `loadFactor` outside the open interval `(0, 1)`) but carried no `<exception>` tag — while the parallel `CelerityMultiMap` / `CelerityMultiSet` and the probabilistic types already document it. `GenerateDocumentationFile` + CS1591-as-error only catches *missing member docs*, not incomplete `<exception>` coverage, so this gap shipped silently. Callers reading IntelliSense saw documented `ArgumentNullException`/`ArgumentException` but no hint that the very arguments the constructor validates first can throw.

**Documentation only — no code or public-surface change.** Build is clean (0 warnings, 0 errors across net8.0/net9.0/net10.0).

## What changed

Added, to each affected constructor, the tag using the existing `CelerityMultiMap` wording:

```csharp
/// <exception cref="ArgumentOutOfRangeException">
/// <paramref name="capacity"/> is negative, or <paramref name="loadFactor"/>
/// is not in the open interval (0, 1).
/// </exception>
```

- Both the **primary** constructor and the **`IEnumerable` source overload** of each type — the source overload can still propagate the exception via its chained primary constructor.
- The `Int`/`Long` non-generic convenience subclasses **re-declare** their own constructors, so those got the tag too (4 constructors each rather than 2).
- In the dictionary source overloads the tag is placed in **actual throw order**: `ArgumentNullException` → `ArgumentOutOfRangeException` → `ArgumentException`.

## Coverage (36 tags across 14 files)

| Type | Constructors tagged |
|---|---|
| `CelerityDictionary` / `CeleritySet` | 2 each |
| `HashCachingDictionary` / `HashCachingSet` | 2 each |
| `PooledCelerityDictionary` / `PooledCeleritySet` | 2 each |
| `RobinHoodDictionary` / `RobinHoodSet` | 2 each |
| `SwissDictionary` / `SwissSet` | 2 each |
| `IntDictionary` / `IntSet` | 4 each (subclass + hasher-generic base) |
| `LongDictionary` / `LongSet` | 4 each (subclass + hasher-generic base) |

The pre-existing `EnsureCapacity` `<exception>` docs and the `CelerityMultiMap`/`CelerityMultiSet` constructors were already correct and are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
