### PR TITLE
docs(hashing): fix misquoted note in StringFnV1AFullHasher (#254)

### DIFF
--- a/src/Celerity.Hashing/StringFnV1AFullHasher.cs
+++ b/src/Celerity.Hashing/StringFnV1AFullHasher.cs
@@ -9,8 +9,8 @@ namespace Celerity.Hashing;
 /// </summary>
 /// <remarks>
 /// This is the full-character-width counterpart to <see cref="StringFnV1AHasher"/>,
-/// and directly answers the note in that hasher's remarks that "for keys with
-/// significant non-ASCII content, a full UTF-8 or UTF-16 hash is preferable."
+/// and directly answers the note in that hasher's remarks that "For Unicode-heavy
+/// workloads, a full UTF-8 or UTF-16 hash is preferable."
 /// Where <see cref="StringFnV1AHasher"/> folds only the low byte of each
 /// character (<c>c &amp; 0xFF</c>) and therefore cannot distinguish characters
 /// that differ only in their upper byte — for example <c>'A'</c> (<c>U+0041</c>)


### PR DESCRIPTION
## Summary

Fixes #254. The XML doc comment for `StringFnV1AFullHasher` presented a **direct quotation** (in quotation marks, attributed to `StringFnV1AHasher`'s remarks) that did not match the source verbatim — the quoted wording was a conflation of two different hashers.

- The quote read: `"for keys with significant non-ASCII content, a full UTF-8 or UTF-16 hash is preferable."`
- `StringFnV1AHasher`'s actual note reads: `"For Unicode-heavy workloads, a full UTF-8 or UTF-16 hash is preferable."`
- The phrase *"for keys with significant non-ASCII content"* actually originates in `StringMurmur3Hasher`, not `StringFnV1AHasher`.

This replaces the misquoted text with the verbatim note from `StringFnV1AHasher`, so the quotation marks now promise a quote that matches its source.

## Scope

One file, doc-only. No behavioral change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
