### PR TITLE
perf(BitSet): add AggressiveInlining to Flip to match Get/Set (#253)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,10 @@ All notable changes to Celerity are documented here. This project follows [Keep 
 
   (Parity facets that genuinely do not apply: **no gh-pages dashboard wiring** — the dashboard `COLLECTIONS` arrays and ship cards are for the *collection* types; the `Celerity.Primitives` utilities, `BitPackingBenchmark` included, are extended-suite microbenchmarks not surfaced on the per-commit collections dashboard, exactly like `VarIntBenchmark` / `SpanBitsBenchmark`. **No cross-collection shared tests** — `BitWriter` / `BitReader` are not open-addressed set/dict types, so the family-wide `Add` / `TryAdd` / `SetConstructorValidation` / `IEnumerableConstructor` suites do not apply, as they do not for `VarInt` / `SpanBits`. **No `ROADMAP.md` status flip** — milestone 2.1.0's `Celerity.Primitives` bit/span work is already `done` and shipped `VarInt` + `SpanBits`; this adds the sequential sub-byte field cursor that sits between them, after the roadmap was otherwise exhausted, the established post-roadmap tier-(c) pattern.)
 
+### Changed
+
+- `BitSet.Flip(int)` now carries `[MethodImpl(MethodImplOptions.AggressiveInlining)]`, matching the two structurally-identical single-bit accessors that bracket it — `Get(int)` and `Set(int, bool)` — which were already marked. `Flip` does the same bounded single-word mask/mutate work (`(uint)index >= (uint)_length` guard, `1UL << (index & WordMask)` bit, `_words[index >> WordShift]` word ref, XOR, `_version++`), so the missing attribute was an inlining asymmetry rather than a deliberate choice: a hot-path bit accessor the JIT was free to leave out-of-line while its siblings inlined. No behavioural, API, or contract change — purely a codegen-consistency fix so all three accessors present the same inlining hint. Closes [#253](https://github.com/marius-bughiu/Celerity/issues/253).
+
 ## [2.2.0] - 2026-07-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,7 +115,7 @@ All notable changes to Celerity are documented here. This project follows [Keep 
 
 ### Changed
 
-- `BitSet.Flip(int)` now carries `[MethodImpl(MethodImplOptions.AggressiveInlining)]`, matching the two structurally-identical single-bit accessors that bracket it — `Get(int)` and `Set(int, bool)` — which were already marked. `Flip` does the same bounded single-word mask/mutate work (`(uint)index >= (uint)_length` guard, `1UL << (index & WordMask)` bit, `_words[index >> WordShift]` word ref, XOR, `_version++`), so the missing attribute was an inlining asymmetry rather than a deliberate choice: a hot-path bit accessor the JIT was free to leave out-of-line while its siblings inlined. No behavioural, API, or contract change — purely a codegen-consistency fix so all three accessors present the same inlining hint. Closes [#253](https://github.com/marius-bughiu/Celerity/issues/253).
+- `BitSet.Flip(int)` is now marked `[MethodImpl(MethodImplOptions.AggressiveInlining)]`, matching the sibling single-bit accessors `Get(int)` and `Set(int, bool)`, which were already inlined. Codegen-hint consistency only — no behavioural, API, or contract change. Closes [#253](https://github.com/marius-bughiu/Celerity/issues/253).
 
 ## [2.2.0] - 2026-07-05
 

--- a/src/Celerity/Collections/BitSet.cs
+++ b/src/Celerity/Collections/BitSet.cs
@@ -190,6 +190,7 @@ public sealed class BitSet : IEnumerable<bool>
     /// <returns>The value of the bit after flipping.</returns>
     /// <exception cref="ArgumentOutOfRangeException"><paramref name="index"/> is
     /// negative or not less than <see cref="Length"/>.</exception>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool Flip(int index)
     {
         if ((uint)index >= (uint)_length)


### PR DESCRIPTION
## What

Adds `[MethodImpl(MethodImplOptions.AggressiveInlining)]` to `BitSet.Flip(int)` so all three single-bit accessors carry the same inlining hint.

`Flip` sits between `Get(int)` and `Set(int, bool)` in `src/Celerity/Collections/BitSet.cs` and does the same bounded single-word work they do:

- `(uint)index >= (uint)_length` bounds guard
- `1UL << (index & WordMask)` bit mask
- `ref ulong word = ref _words[index >> WordShift]` word ref
- mask/mutate (`^=`) + `_version++`

Both `Get` and `Set` were already marked `[MethodImpl(AggressiveInlining)]`; `Flip` was not. Given the three are structurally identical single-bit accessors, the missing attribute reads as an inlining asymmetry rather than a deliberate choice — a hot-path bit accessor the JIT was free to leave out-of-line while its siblings inlined.

## Why

Consistency-of-intent in a library that inlines its accessors deliberately. No behavioural, API, or contract change — purely a codegen hint so all three accessors present the same inlining directive.

## Testing

- `dotnet build -c Release` — clean (0 warnings, 0 errors)
- `dotnet test --filter FullyQualifiedName~BitSet` — 55/55 passing

Per the issue's scope note, the change is small enough to apply as a consistency fix matching `Get`/`Set` rather than gate on a dedicated benchmark.

Closes #253

🤖 Generated with [Claude Code](https://claude.com/claude-code)
