### PR TITLE
docs(DisjointSet): fix parameterless-ctor capacity claim

### DIFF
--- a/src/Celerity/Collections/DisjointSet.cs
+++ b/src/Celerity/Collections/DisjointSet.cs
@@ -62,7 +62,10 @@ public sealed class DisjointSet<T> : IReadOnlyCollection<T>
     // bump it — the observable partition is unchanged.
     private int _version;
 
-    /// <summary>Initializes a new, empty disjoint-set with a small default capacity.</summary>
+    /// <summary>
+    /// Initializes a new, empty disjoint-set with no pre-allocated capacity. The first
+    /// <see cref="Add"/> allocates the backing arrays.
+    /// </summary>
     public DisjointSet()
         : this(0)
     {


### PR DESCRIPTION
## What

The parameterless `DisjointSet()` constructor's XML summary claimed it initializes the set "with a small default capacity." Reworded to state it pre-allocates nothing and that the first `Add` allocates the backing arrays.

## Why

`DisjointSet()` forwards `: this(0)`, and the capacity constructor treats `0` specially — it assigns `Array.Empty<T>()`/`Array.Empty<int>()` to all three backing arrays, so `Capacity` returns `0`. The `DefaultCapacity` of 4 only takes effect on the first `Grow()`. The old wording implied storage was pre-sized at construction, which is inaccurate. The new wording mirrors the sibling `Deque()` constructor doc, which already documents this "allocate on first use" behavior correctly.

Doc-only change; no behavioral impact.

## Test plan

- [x] `dotnet build` — succeeds, 0 warnings / 0 errors
- [x] Doc-only change; no runtime behavior affected, existing tests unaffected
