### PR TITLE
docs(CuckooFilter): correct when IsFull clears

### DIFF
--- a/src/Celerity/Collections/CuckooFilter.cs
+++ b/src/Celerity/Collections/CuckooFilter.cs
@@ -226,7 +226,9 @@ public class CuckooFilter<T, THasher> where THasher : struct, IHashProvider<T>
     /// <summary>
     /// Gets a value indicating whether the filter is full: an insertion has exhausted its eviction budget and a
     /// fingerprint is parked in the single-entry victim cache. While <c>true</c>, <see cref="Add"/> throws and
-    /// <see cref="TryAdd"/> returns <c>false</c>; a successful <see cref="Remove"/> clears it.
+    /// <see cref="TryAdd"/> returns <c>false</c>. It clears when a <see cref="Remove"/> either takes the parked
+    /// victim itself or frees a slot in one of the victim's two candidate buckets so the victim can be
+    /// re-homed; a <see cref="Remove"/> elsewhere in the table leaves it <c>true</c>.
     /// </summary>
     public bool IsFull => _hasVictim;
 


### PR DESCRIPTION
## What

Corrected the `CuckooFilter.IsFull` XML summary, which claimed "a successful `Remove` clears it." Reworded to state the precise condition under which `IsFull` (i.e. `_hasVictim`) actually clears.

## Why

`IsFull` returns `_hasVictim`. On a successful `Remove` the filter only stops being full in two cases:

1. The removed element *is* the parked victim (the `_hasVictim && _victimFingerprint == fingerprint && ...` branch clears it directly), or
2. The removal frees a slot in one of the victim's two candidate buckets, so `RelocateVictimIfPossible()` can re-home the parked fingerprint.

A `Remove` that succeeds against an unrelated bucket leaves both victim-candidate buckets full, so `RelocateVictimIfPossible()` is a no-op and `_hasVictim`/`IsFull` stays `true`. The old wording ("a successful Remove clears it") implied any removal recovers the filter, which is not the case.

Doc-only change; no behavioral impact.

## Test plan

- [x] `dotnet build` — succeeds, 0 errors
- [x] Doc-only change; runtime behavior and existing tests unaffected
