### PR TITLE
docs(FrozenCeleritySet): document ArgumentException on the derived ctor

### DIFF
--- a/src/Celerity/Collections/FrozenCeleritySet.cs
+++ b/src/Celerity/Collections/FrozenCeleritySet.cs
@@ -24,6 +24,10 @@ public sealed class FrozenCeleritySet : FrozenCeleritySet<StringFnV1AHasher>
     /// duplicate-element and <c>null</c>-element contract.
     /// </param>
     /// <exception cref="ArgumentNullException"><paramref name="source"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentException">
+    /// <paramref name="source"/> holds <c>2^30</c> or more distinct non-<c>null</c> elements,
+    /// which a power-of-two frozen table cannot represent.
+    /// </exception>
     public FrozenCeleritySet(IEnumerable<string> source)
         : base(source)
     {


### PR DESCRIPTION
## What

Added the missing `<exception cref="ArgumentException">` element to the non-generic `FrozenCeleritySet(IEnumerable<string>)` constructor's XML docs.

## Why

That constructor is `: base(source)` over `FrozenCeleritySet<THasher>(IEnumerable<string>)`, whose documented (and reachable) contract throws `ArgumentException` when `source` holds `2^30` or more distinct non-`null` elements — a count a power-of-two frozen table cannot represent. The derived ctor documented only `ArgumentNullException`, so a caller reading its docs would not see the size-ceiling exception.

The parallel type `FrozenCelerityDictionary` already carries this `ArgumentException` doc on its derived ctor, so this change restores doc parity between the two frozen collections.

Doc-only change; no behavioral impact.

## Test plan

- [x] `dotnet build` — succeeds, 0 errors (no CS1591/doc warnings)
- [x] Doc-only change; runtime behavior and existing tests unaffected
