### PR TITLE
docs(StringFnV1AHasher): replace tutorial-style loop comment

### DIFF
--- a/src/Celerity.Hashing/StringFnV1AHasher.cs
+++ b/src/Celerity.Hashing/StringFnV1AHasher.cs
@@ -36,8 +36,9 @@ public struct StringFnV1AHasher : IHashProvider<string>
         uint hash = offsetBasis;
         foreach (char c in key)
         {
-            // Convert char to its lower byte; you may also want to consider
-            // encoding specifics if you deal with non-ASCII characters.
+            // Fold only the low byte of each UTF-16 code unit. Characters that share a
+            // low byte but differ in their high byte (most non-ASCII) collide here; use
+            // StringFnV1AFullHasher when that distinction matters.
             hash ^= (byte)(c & 0xFF);
             hash *= fnvPrime;
         }

--- a/src/Celerity.Hashing/StringFnV1AHasher.cs
+++ b/src/Celerity.Hashing/StringFnV1AHasher.cs
@@ -37,7 +37,7 @@ public struct StringFnV1AHasher : IHashProvider<string>
         foreach (char c in key)
         {
             // Fold only the low byte of each UTF-16 code unit. Characters that share a
-            // low byte but differ in their high byte (most non-ASCII) collide here; use
+            // low byte but differ in their high byte (i.e., U+0100 and above) collide here; use
             // StringFnV1AFullHasher when that distinction matters.
             hash ^= (byte)(c & 0xFF);
             hash *= fnvPrime;


### PR DESCRIPTION
## What

Replaced a leftover tutorial-style comment in the `StringFnV1AHasher.Hash` inner loop with a declarative one describing what the code actually does.

## Why

The old comment — "Convert char to its lower byte; you may also want to consider encoding specifics if you deal with non-ASCII characters" — is written in second person and reads like scaffolding left over from a tutorial. It is also out of step with the precise, declarative comments its sibling hashers carry for the same low-byte operation (e.g. `StringDjb2Hasher`, `StringFnV1AFullHasher`), which state exactly what is folded and what collides. The replacement states the low-byte-only behavior and its collision implication and points at `StringFnV1AFullHasher` for the full-width alternative.

Comment-only change; no code or behavioral impact.

## Test plan

- [x] `dotnet build` — succeeds, 0 errors
- [x] Comment-only change; runtime behavior and existing tests unaffected
