### PR TITLE
fix(pooled): throw ObjectDisposedException from Count/Keys/Values after Dispose (#296)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to Celerity are documented here. This project follows [Keep 
 
 - **`Trie<TValue>`** in `Celerity.Collections` — an ordered prefix tree mapping `string` keys to values, filling a BCL gap (.NET ships no trie). `GetByPrefix` lists every entry whose key starts with a prefix in `O(prefix + matches)` and in ascending key order, and `TryGetLongestPrefix` finds the longest stored key that is a prefix of a query in `O(query)` — the autocomplete, longest-prefix-routing, and ordered-iteration workloads a `Dictionary<string, TValue>` can only answer with an `O(n)` scan plus a `StartsWith` per key. Exact `Add` / `TryGetValue` favour a `Dictionary`, so the trie earns its place on the prefix operations. Implements `IReadOnlyDictionary<string, TValue?>`; not thread-safe. Closes [#285](https://github.com/marius-bughiu/Celerity/issues/285).
 
+### Fixed
+
+- `PooledCelerityDictionary` and `PooledCeleritySet` now throw `ObjectDisposedException` from their read accessors (`Count`, and the dictionary's `Keys` / `Values`) after `Dispose`, matching the documented "every member throws after disposal" contract. Previously these returned a silent, misleading result over arrays already returned to `ArrayPool.Shared`. Closes [#296](https://github.com/marius-bughiu/Celerity/issues/296).
+
 ## [2.3.0] - 2026-07-19
 
 ### Added

--- a/src/Celerity.Tests/Collections/PooledCelerityDictionaryTests.cs
+++ b/src/Celerity.Tests/Collections/PooledCelerityDictionaryTests.cs
@@ -274,6 +274,15 @@ public class PooledCelerityDictionaryTests
         Assert.Throws<ObjectDisposedException>(() => map.TryAdd(2, 2));
         Assert.Throws<ObjectDisposedException>(() => map.Clear());
         Assert.Throws<ObjectDisposedException>(() => map.GetEnumerator());
+        Assert.Throws<ObjectDisposedException>(() => map.EnsureCapacity(64));
+        Assert.Throws<ObjectDisposedException>(() => map.TrimExcess());
+        // Read accessors must also honour the disposed contract: Dispose returns
+        // the backing arrays to the pool, so a silent Count / Keys / Values here
+        // would report over — or enumerate — buffers the pool may have re-handed
+        // out. Regression for #296.
+        Assert.Throws<ObjectDisposedException>(() => _ = map.Count);
+        Assert.Throws<ObjectDisposedException>(() => _ = map.Keys);
+        Assert.Throws<ObjectDisposedException>(() => _ = map.Values);
     }
 
     [Fact]

--- a/src/Celerity.Tests/Collections/PooledCeleritySetTests.cs
+++ b/src/Celerity.Tests/Collections/PooledCeleritySetTests.cs
@@ -233,6 +233,11 @@ public class PooledCeleritySetTests
         Assert.Throws<ObjectDisposedException>(() => set.Overlaps(new[] { 3 }));
         Assert.Throws<ObjectDisposedException>(() => set.SetEquals(new[] { 3 }));
         Assert.Throws<ObjectDisposedException>(() => set.CopyTo(new int[4], 0));
+        // Read accessor must also honour the disposed contract: Dispose zeroes
+        // _count and returns the backing array to the pool, so a silent Count
+        // here would report 0 over a buffer the pool may have re-handed out.
+        // Regression for #296.
+        Assert.Throws<ObjectDisposedException>(() => _ = set.Count);
     }
 
     [Fact]

--- a/src/Celerity/Collections/PooledCelerityDictionary.cs
+++ b/src/Celerity/Collections/PooledCelerityDictionary.cs
@@ -202,7 +202,15 @@ public class PooledCelerityDictionary<TKey, TValue, THasher>
     /// <summary>
     /// Gets the number of key/value pairs contained in the dictionary.
     /// </summary>
-    public int Count => _count;
+    /// <exception cref="ObjectDisposedException">The dictionary has been disposed.</exception>
+    public int Count
+    {
+        get
+        {
+            ThrowIfDisposed();
+            return _count;
+        }
+    }
 
     /// <summary>
     /// Gets or sets the value associated with the specified key.
@@ -619,13 +627,29 @@ public class PooledCelerityDictionary<TKey, TValue, THasher>
     /// Gets an enumerable view over the keys in the dictionary. The view is a
     /// lightweight struct and iterating it does not allocate.
     /// </summary>
-    public KeyCollection Keys => new KeyCollection(this);
+    /// <exception cref="ObjectDisposedException">The dictionary has been disposed.</exception>
+    public KeyCollection Keys
+    {
+        get
+        {
+            ThrowIfDisposed();
+            return new KeyCollection(this);
+        }
+    }
 
     /// <summary>
     /// Gets an enumerable view over the values in the dictionary. The view is a
     /// lightweight struct and iterating it does not allocate.
     /// </summary>
-    public ValueCollection Values => new ValueCollection(this);
+    /// <exception cref="ObjectDisposedException">The dictionary has been disposed.</exception>
+    public ValueCollection Values
+    {
+        get
+        {
+            ThrowIfDisposed();
+            return new ValueCollection(this);
+        }
+    }
 
     /// <summary>
     /// A struct enumerator over a

--- a/src/Celerity/Collections/PooledCeleritySet.cs
+++ b/src/Celerity/Collections/PooledCeleritySet.cs
@@ -192,7 +192,15 @@ public class PooledCeleritySet<T, THasher> : ISet<T>, IDisposable
     /// <summary>
     /// Gets the number of elements contained in the set.
     /// </summary>
-    public int Count => _count;
+    /// <exception cref="ObjectDisposedException">The set has been disposed.</exception>
+    public int Count
+    {
+        get
+        {
+            ThrowIfDisposed();
+            return _count;
+        }
+    }
 
     /// <summary>
     /// Adds the specified element to the set.


### PR DESCRIPTION
## What & why

`PooledCelerityDictionary` and `PooledCeleritySet` both document — in the class `<remarks>`, the `_disposed` field comment, and the `Dispose()` summary — that **"after `Dispose` every member throws `ObjectDisposedException`."** Several read accessors did not honour that contract:

- `PooledCelerityDictionary.Count`, `Keys`, `Values`
- `PooledCeleritySet.Count`

`Dispose()` sets `_count = 0` and returns the backing key/value arrays to `ArrayPool<T>.Shared`. So a post-dispose `Count` read returned a silent `0`, and `Keys` / `Values` handed back a view over arrays already back in the pool — potentially observing buffers the pool has since re-handed to another caller. That is a correctness/robustness gap, not just a doc nit. Fixes #296.

The fix routes all four accessors through the existing `ThrowIfDisposed()` guard that the rest of each type's surface already uses, so the code now matches the long-documented contract. No behaviour change before disposal.

## Parity checklist (bug fix)

- **(a) Dedicated tests** — extended the existing `UseAfterDispose_ShouldThrowObjectDisposedException` fact in `PooledCelerityDictionaryTests` (adds `Count` / `Keys` / `Values`, plus the previously-missing `EnsureCapacity` / `TrimExcess`) and `PooledCeleritySetTests` (adds `Count`). These assertions fail on `main`.
- **(b) Cross-collection shared tests** — N/A: the two pooled types are the only `IDisposable` collections and there is no shared use-after-dispose test to extend.
- **(c) Benchmarks / (d) dashboard** — N/A: no perf or public-shape change.
- **(e) Docs** — no change: `docs/api/collections.md` already states "after it every member throws `ObjectDisposedException`" for both pooled types; this fix makes the code match the already-correct docs.
- **(f) CHANGELOG** — added a `### Fixed` bullet under `[Unreleased]`.
- **(g) ROADMAP** — N/A: pooled collections already shipped/`done`.

## Test plan

- [x] `dotnet build` (net8.0) — clean, 0 warnings.
- [x] `dotnet test` (net8.0) — full suite **4263 passed, 0 failed**; pooled subset 233 passed.
- [ ] CI matrix (net8.0 / net9.0 / net10.0 × Windows / Linux / macOS) green.
- [ ] No gh-pages dashboard refresh needed (no benchmark/collection surface change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
