### PR TITLE
docs(CLAUDE.md): require agents to watch a PR until its review loop closes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,3 +63,27 @@ Too verbose (avoid): a full paragraph reciting the `(uint)index >= (uint)_length
 - Bug fixes ship with a regression test that fails on `main`.
 - Never add `<Version>` / `<PackageVersion>` / `<AssemblyVersion>` to any `.csproj` — MinVer owns versioning from git tags.
 - When you act on a PR review comment, always **reply to that comment** with your conclusion — whether you agree or not, and what you changed (reference the commit) — **and mark the thread resolved**. Do this for every comment you address, so it's clear which are handled and which are still open. If you disagree and make no change, still reply with the reasoning and leave the thread unresolved for the maintainer to decide.
+
+## After opening a PR: watch it until the review is settled
+
+**Opening the PR is not the end of the work.** GitHub Copilot reviews every PR in this repo automatically. A session that opens a PR and stops has left the job half done — stay with the PR until the review loop is genuinely closed.
+
+1. **Wait for the Copilot review to land.** It usually posts within a few minutes of the PR opening (longer for large diffs). Poll rather than assume:
+
+   ```bash
+   gh pr view <N> -R marius-bughiu/Celerity --json reviews,comments,statusCheckRollup
+   ```
+
+   Inline review comments come from a separate endpoint — check both:
+
+   ```bash
+   gh api repos/marius-bughiu/Celerity/pulls/<N>/comments
+   ```
+
+   Keep polling on a sensible interval (a couple of minutes between checks). Do not conclude "Copilot had no comments" from a single early check — only from a check made *after* the review itself has appeared in `reviews`.
+
+2. **Address every comment.** Apply the fix, or push back with reasoning — the existing rule above still governs: reply to each comment saying what you concluded and what you changed (referencing the commit), resolve the threads you handled, and leave a thread unresolved only when you disagree and want the maintainer to decide.
+
+3. **Then keep watching.** Pushing fixes re-triggers Copilot, and the new review can raise fresh comments on the code you just wrote. Go back to step 1 and repeat: wait for the new review, address what it raises, push, wait again. Also re-check CI on each push — a green PR with unanswered comments and a commented PR with red CI are both unfinished.
+
+4. **Stop only when the loop is quiet and you are satisfied with the result.** That means: the latest review has landed with nothing left unaddressed, CI is green, and you have actually reviewed your own fixes rather than applying suggestions mechanically. Copilot suggestions are advice, not orders — an incorrect or scope-inflating suggestion should get a reasoned reply, not a reflexive commit. If something genuinely needs the maintainer (a design call, a suggestion you disagree with), say so explicitly in the session summary along with the PR URL and which threads are still open.


### PR DESCRIPTION
## What

Adds a section to `CLAUDE.md` — **"After opening a PR: watch it until the review is settled"** — making the post-PR review loop an explicit part of an agent session's work rather than an optional extra.

## Why

`CLAUDE.md` already told agents to reply to and resolve review comments, but nothing said they had to *stick around* for the review to arrive. Copilot reviews every PR here automatically and posts a few minutes after the PR opens, so a session that opened a PR and stopped would routinely leave comments unanswered.

## The rule

1. **Wait for the Copilot review to land** — poll `gh pr view <N> --json reviews,comments,statusCheckRollup` *and* `gh api repos/marius-bughiu/Celerity/pulls/<N>/comments`, since inline review comments come from a separate endpoint. "No comments" is only a valid conclusion from a check made *after* the review shows up in `reviews`, never from a single early poll.
2. **Address every comment** under the existing reply-and-resolve rule — fix or push back with reasoning, reference the commit, resolve what you handled, leave a thread open only when the maintainer should decide.
3. **Keep watching after pushing fixes** — a push re-triggers Copilot and the new review can raise fresh comments on the just-pushed code. Re-check CI each time too.
4. **Stop only when the loop is quiet and the result is genuinely satisfactory.** Copilot suggestions are advice, not orders; an incorrect or scope-inflating suggestion earns a reasoned reply, not a reflexive commit.

The `celerity---maintainer` scheduled task has been updated in parallel (outside this repo) with the same loop as an explicit step between "open the PR" and "summarize". The other Celerity tasks that open PRs inherit the rule from `CLAUDE.md`.

## Test plan

- [x] Docs-only change — no source, tests, benchmarks, or dashboard touched.
- [ ] CI matrix green (build/test unaffected by this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
