### PR TITLE
docs(StringInternTable): qualify the "never allocates" claim on GetOrAdd(string)

### DIFF
--- a/docs/api/collections.md
+++ b/docs/api/collections.md
@@ -3937,7 +3937,7 @@ public StringInternTable(int capacity = 16, float loadFactor = 0.75f)
 |--------|-------------|
 | `int Count` | Number of distinct strings interned. |
 | `string GetOrAdd(ReadOnlySpan<char> key)` | The canonical instance for those characters, allocating one only on a miss. |
-| `string GetOrAdd(string key)` | The canonical instance; on a miss the supplied instance itself becomes canonical, so this never allocates. Throws `ArgumentNullException` on `null`. |
+| `string GetOrAdd(string key)` | The canonical instance; on a miss the supplied instance itself becomes canonical, so this never allocates a `string` (an insert past the load factor still grows the backing array). Throws `ArgumentNullException` on `null`. |
 | `bool TryGet(ReadOnlySpan<char> key, out string? value)` | Pure lookup — never interns. `value` is `null` on a miss. |
 | `bool Contains(ReadOnlySpan<char> key)` | Whether those characters are already interned. |
 | `bool Contains(string key)` | The same. Throws `ArgumentNullException` on `null`. |

--- a/src/Celerity/Collections/StringInternTable.cs
+++ b/src/Celerity/Collections/StringInternTable.cs
@@ -188,9 +188,10 @@ public class StringInternTable<THasher> : IReadOnlyCollection<string>
     /// </returns>
     /// <exception cref="ArgumentNullException"><paramref name="key"/> is <c>null</c>.</exception>
     /// <remarks>
-    /// This overload never allocates: on a miss the supplied instance becomes the canonical
-    /// one. It is the shape to use when you already hold a <see cref="string"/> and want to
-    /// collapse duplicates.
+    /// This overload never allocates a <see cref="string"/>: on a miss the supplied instance
+    /// becomes the canonical one. (An insert that crosses the load factor still grows the
+    /// backing array, as any hash table does.) It is the shape to use when you already hold a
+    /// <see cref="string"/> and want to collapse duplicates.
     /// </remarks>
     public string GetOrAdd(string key)
     {


### PR DESCRIPTION
## What

The `<remarks>` on `StringInternTable<THasher>.GetOrAdd(string)` said "This overload never allocates", and the API-reference table said "so this never allocates". Both now say it never allocates a *`string`*, with a parenthetical noting that an insert past the load factor still grows the backing array. No code changes.

## Why

The claim is an absolute, and `Resize()` allocates a new `string?[]` on the growth path — so as written it is not true. Everywhere else the type is careful to scope the claim: the class summary says it "allocates a `string` *only on a miss*", and the span overload's summary says "allocating one *only* if those characters are not already interned". This one remark had dropped the qualifier, which matters more than usual here because callers read these docs specifically to reason about GC pressure.

## Test plan

- [x] `dotnet build` — succeeds, 0 warnings for `Celerity.csproj`
- [x] No `dotnet test` run: the change is an XML doc comment and a Markdown table cell, with no effect on emitted IL
