### PR TITLE
fix(PartialSort): reject a TopK destination that overlaps its source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ All notable changes to Celerity are documented here. This project follows [Keep 
 
 ### Fixed
 
-- `PartialSort.TopK` now throws `ArgumentException` when its `destination` overlaps its `source`, instead of quietly returning a wrong answer and writing to the source it documents as untouched. The destination is the heap, so an aliasing buffer rewrites the source as it scans. Matches the buffer-aliasing checks `RadixSort` and `CountingSort` already make.
+- `PartialSort.TopK` now throws `ArgumentException` when its `destination` overlaps its `source`, instead of silently returning a wrong answer and writing to the source it documents as untouched. Disjoint slices of one array are still accepted, matching `RadixSort` and `CountingSort`.
 - Eight documentation links pointed at anchors that do not exist: seven `CeleritySet` / `SwissSet` references in `docs/api/collections.md` and one in `CHANGELOG.md`. GitHub deletes `<`, `>` and `,` from a heading without substituting a separator, so `CeleritySet&lt;T, THasher&gt;` anchors as `#celeritysett-thasher`, not the `#celerityset-t-thasher` everyone writes. Closes [#339](https://github.com/marius-bughiu/Celerity/issues/339).
 
 ## [2.5.0] - 2026-08-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to Celerity are documented here. This project follows [Keep 
 
 ### Fixed
 
+- `PartialSort.TopK` now throws `ArgumentException` when its `destination` overlaps its `source`, instead of quietly returning a wrong answer and writing to the source it documents as untouched. The destination is the heap, so an aliasing buffer rewrites the source as it scans. Matches the buffer-aliasing checks `RadixSort` and `CountingSort` already make.
 - Eight documentation links pointed at anchors that do not exist: seven `CeleritySet` / `SwissSet` references in `docs/api/collections.md` and one in `CHANGELOG.md`. GitHub deletes `<`, `>` and `,` from a heading without substituting a separator, so `CeleritySet&lt;T, THasher&gt;` anchors as `#celeritysett-thasher`, not the `#celerityset-t-thasher` everyone writes. Closes [#339](https://github.com/marius-bughiu/Celerity/issues/339).
 
 ## [2.5.0] - 2026-08-02

--- a/docs/api/sorting.md
+++ b/docs/api/sorting.md
@@ -182,6 +182,7 @@ struct hashers follow. Nulls sort first under the natural order, matching `Compa
 | `TopK<T, TComparer>(ReadOnlySpan<T> source, Span<T> destination, TComparer comparer)` | The same under a custom order — pass a reversing comparer to take the *smallest*. |
 
 **Exceptions.** `ArgumentOutOfRangeException` when `count` is negative or greater than `keys.Length`.
+`ArgumentException` when a `TopK` `destination` shares storage with its `source`.
 
 **Properties worth relying on.**
 
@@ -195,7 +196,8 @@ struct hashers follow. Nulls sort first under the natural order, matching `Compa
   an `IComparer<T>`-typed helper and so boxes a `struct` comparer on every call. If you want
   introsort's constant factor over a whole span, call the BCL directly.
 - **Not stable**, in any form.
-- **`TopK` never writes to `source`** and allocates nothing — the destination *is* the heap.
+- **`TopK` never writes to `source`** and allocates nothing — the destination *is* the heap, which
+  is why a `destination` overlapping `source` is rejected rather than silently answered wrongly.
 
 ```csharp
 using Celerity.Sorting;

--- a/docs/api/sorting.md
+++ b/docs/api/sorting.md
@@ -182,7 +182,8 @@ struct hashers follow. Nulls sort first under the natural order, matching `Compa
 | `TopK<T, TComparer>(ReadOnlySpan<T> source, Span<T> destination, TComparer comparer)` | The same under a custom order — pass a reversing comparer to take the *smallest*. |
 
 **Exceptions.** `ArgumentOutOfRangeException` when `count` is negative or greater than `keys.Length`.
-`ArgumentException` when a `TopK` `destination` shares storage with its `source`.
+`ArgumentException` when a `TopK` `destination` shares storage with its `source`. As everywhere else
+in the package, only genuine overlap is rejected — two disjoint slices of one array are fine.
 
 **Properties worth relying on.**
 

--- a/src/Celerity.Sorting/PartialSort.cs
+++ b/src/Celerity.Sorting/PartialSort.cs
@@ -130,6 +130,7 @@ public static class PartialSort
     /// <param name="source">The elements to scan. Not modified.</param>
     /// <param name="destination">Receives the top <c>destination.Length</c> elements; its length is <c>k</c>.</param>
     /// <returns>The number of elements written — <c>destination.Length</c>, or <c>source.Length</c> when the source is shorter.</returns>
+    /// <exception cref="ArgumentException"><paramref name="destination"/> shares storage with <paramref name="source"/>.</exception>
     public static int TopK<T>(ReadOnlySpan<T> source, Span<T> destination)
         where T : IComparable<T> =>
         TopK<T, ComparableComparer<T>>(source, destination, default);
@@ -148,9 +149,15 @@ public static class PartialSort
     /// <param name="destination">Receives the top <c>destination.Length</c> elements; its length is <c>k</c>.</param>
     /// <param name="comparer">The comparer defining the order.</param>
     /// <returns>The number of elements written — <c>destination.Length</c>, or <c>source.Length</c> when the source is shorter.</returns>
+    /// <exception cref="ArgumentException"><paramref name="destination"/> shares storage with <paramref name="source"/>.</exception>
     public static int TopK<T, TComparer>(ReadOnlySpan<T> source, Span<T> destination, TComparer comparer)
         where TComparer : struct, IComparer<T>
     {
+        // The destination *is* the heap, so an aliasing destination would rewrite the source the
+        // method promises not to touch and read back its own partial output — a wrong answer rather
+        // than a failure, which is the same reason the two other sorters reject overlapping buffers.
+        SortingGuard.RequireDistinctStorage(source, destination, nameof(destination));
+
         int k = destination.Length;
         if (k == 0)
         {

--- a/src/Celerity.Tests/Sorting/SortingArgumentValidationTests.cs
+++ b/src/Celerity.Tests/Sorting/SortingArgumentValidationTests.cs
@@ -146,6 +146,30 @@ public class SortingArgumentValidationTests
     }
 
     [Fact]
+    public void TopK_ShouldThrow_WhenTheDestinationSharesStorageWithTheSource()
+    {
+        int[] buffer = [5, 1, 4, 2, 3];
+
+        var whole = Assert.Throws<ArgumentException>(
+            () => PartialSort.TopK<int>(buffer, buffer.AsSpan()));
+        Assert.Equal("destination", whole.ParamName);
+
+        var partial = Assert.Throws<ArgumentException>(
+            () => PartialSort.TopK<int>(buffer.AsSpan(0, 4), buffer.AsSpan(3, 2)));
+        Assert.Equal("destination", partial.ParamName);
+    }
+
+    [Fact]
+    public void TopK_ShouldSucceed_WhenTheDestinationOnlyNeighboursTheSource()
+    {
+        // Co-residence in one buffer is fine; only genuine overlap is rejected.
+        int[] buffer = [5, 1, 4, 2, 0, 0];
+
+        Assert.Equal(2, PartialSort.TopK<int>(buffer.AsSpan(0, 4), buffer.AsSpan(4, 2)));
+        Assert.Equal([5, 4], buffer.AsSpan(4, 2).ToArray());
+    }
+
+    [Fact]
     public void ArgSort_ShouldThrow_WhenTheIndexBufferSharesStorageWithTheKeys()
     {
         int[] buffer = [3, 1, 2];


### PR DESCRIPTION
## What

`PartialSort.TopK` now throws `ArgumentException` when its `destination` shares storage with its `source`, using the same `SortingGuard.RequireDistinctStorage` check `RadixSort` and `CountingSort` already apply to every pair of buffers they write. The exception is documented on both `TopK` overloads and in `docs/api/sorting.md`, and a regression test pins it — including the negative case, that two non-overlapping slices of one array remain legal.

## Why

`TopK` builds its min-heap **in the destination** (`Span<T> heap = destination;`) and then keeps reading `source[i]` for the rest of the scan. If the two overlap, the heap writes land on top of source elements that have not been consumed yet: the answer comes out wrong *and* the source is modified. Both outcomes contradict what the type documents in three places — the `<summary>` says "without modifying `source`", `docs/api/sorting.md` says "`TopK` never writes to `source`", and the README says the heap runs "over a span it never writes to". Nothing checked it, so the failure was silent.

Every other public buffer-taking entry point in `Celerity.Sorting` rejects this class of aliasing outright, for exactly the reason `SortingGuard` states: overlapping buffers corrupt the result rather than failing. `TopK` was the one gap.

The alternative considered was the `SortedSpan` treatment — `Debug.Assert` only, unchecked in Release. That fits `SortedSpan`, whose entire value proposition is that Release checks nothing, but not `PartialSort`, which sits in a package where the sibling sorters throw. One `Overlaps` call ahead of an `O(n log k)` scan is not measurable, and it keeps the package's argument contract uniform. Happy to switch to the assert-only form if you'd rather match `SortedSpan`.

## Test plan

- [x] `dotnet build` — succeeds, no new warnings
- [x] `dotnet test` — 5,543 passed, 0 failed (net10.0)
- [x] New: `TopK_ShouldThrow_WhenTheDestinationSharesStorageWithTheSource` — full alias and partial overlap, both report `destination` as the parameter name
- [x] New: `TopK_ShouldSucceed_WhenTheDestinationOnlyNeighboursTheSource` — co-residence in one array is still accepted, and still produces the right answer
- [x] Existing `TopK` tests (including `TopK_ShouldNotModifyTheSource_WhenItScans`) unaffected

---

Found by the weekly `celerity---code-review` sweep.
