### PR TITLE
docs(build): stop claiming Celerity.Sorting is published at the validation baseline

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -97,12 +97,18 @@
     older surface, so a break introduced after it goes unnoticed. The ritual is
     written up in CONTRIBUTING.md, section "Cutting a release".
 
-    All seven shipped packages (Celerity.Collections / Celerity.Hashing /
-    Celerity.Primitives / Celerity.Sorting / Celerity.Ring / Celerity.Sentinel /
-    Celerity.Cardinality) are published at this baseline and share it. A brand-new package has no
+    Six of the seven packages (Celerity.Collections / Celerity.Hashing /
+    Celerity.Primitives / Celerity.Ring / Celerity.Sentinel / Celerity.Cardinality)
+    are published at this baseline and share it. A brand-new package has no
     published predecessor to validate against, and asking for one fails the
     restore, so its .csproj sets CelerityNoPublishedBaseline to true until its
     first release ships, then drops the property.
+
+    Celerity.Sorting is that case right now: it is unreleased, so it carries the
+    property and is NOT validated against anything. Whoever cuts the release that
+    first publishes it must delete the property from Celerity.Sorting.csproj in
+    the same follow-up commit that bumps the baseline below, or the package keeps
+    shipping unvalidated.
 
     Only the baseline version lives here, so there is exactly one line to bump.
     Turning validation on has to happen later, in Directory.Build.targets, where


### PR DESCRIPTION
## What

Corrects the `<CelerityPackageValidationBaseline>` comment in `src/Directory.Build.props`. It listed all seven packages as sharing the baseline; `Celerity.Sorting` does not. The comment now names the six that do, states that Sorting is the first-release exception, and says explicitly that its `CelerityNoPublishedBaseline` property must be deleted in the same follow-up commit that bumps the baseline past its first release.

## Why

`src/Celerity.Sorting/Celerity.Sorting.csproj` sets `<CelerityNoPublishedBaseline>true</CelerityNoPublishedBaseline>` — correctly, since the package is still in `[Unreleased]` and has no published predecessor. `Directory.Build.targets` reads that property and omits `PackageValidationBaselineVersion`, so **`Celerity.Sorting` is currently validated against nothing**.

Meanwhile the props comment said:

> All seven shipped packages (Celerity.Collections / Celerity.Hashing / Celerity.Primitives / **Celerity.Sorting** / …) are published at this baseline and share it.

…and then described the first-release escape hatch in the next sentence without connecting it to Sorting. The comment contradicts itself, and it is not decorative: it is the release ritual, and the paragraph above it says in as many words "this is the part that rots". A maintainer cutting the release that first publishes Sorting could reasonably read this, bump the baseline, and never think to delete the property — leaving the package permanently unvalidated with every gate green. That is the same failure shape as [#314](https://github.com/marius-bughiu/Celerity/issues/314) and [#315](https://github.com/marius-bughiu/Celerity/issues/315).

Comment-only; no property values or build behaviour change.

## Test plan

- [x] `dotnet build` — succeeds, 0 errors (the comment parses; a malformed props comment surfaces as a bogus empty-`TargetFramework` error, so a clean build is the check that matters here)
- [x] No `--` sequence introduced inside the XML comment
- [x] Verified the claim: only `Celerity.Sorting.csproj` sets `CelerityNoPublishedBaseline`, and `Directory.Build.targets:30` gates `PackageValidationBaselineVersion` on it

---

Found by the weekly `celerity---code-review` sweep.
