### PR TITLE
test: make test-project warnings fail (#332)

### DIFF
--- a/src/Celerity.Tests/Celerity.Tests.csproj
+++ b/src/Celerity.Tests/Celerity.Tests.csproj
@@ -4,6 +4,14 @@
     <TargetFrameworks>$(CelerityTargetFrameworks)</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+
+    <!--
+      #332: These assertions intentionally exercise the collection's own Contains
+      and Count implementations. Replacing them with the xUnit alternatives would
+      route through IEnumerable and stop testing the probe paths under test.
+    -->
+    <NoWarn>$(NoWarn);xUnit2013;xUnit2017;xUnit2027</NoWarn>
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>

--- a/src/Celerity.Tests/Collections/SetIEnumerableConstructorTests.cs
+++ b/src/Celerity.Tests/Collections/SetIEnumerableConstructorTests.cs
@@ -480,12 +480,12 @@ public class SetIEnumerableConstructorTests
     public void CeleritySet_ShouldSilentlyDedupe_DuplicateNullElements()
     {
         // null is the out-of-band slot for reference-typed sets — ensure dedupe covers it.
-        var source = new string?[] { "a", null, "b", null, "c", null };
+        var source = new[] { "a", null!, "b", null!, "c", null! };
 
-        var set = new CeleritySet<string?, StringFnV1AHasher>(source);
+        var set = new CeleritySet<string, StringFnV1AHasher>(source);
 
         Assert.Equal(4, set.Count);
-        Assert.True(set.Contains(null));
+        Assert.True(set.Contains(null!));
         Assert.True(set.Contains("a"));
         Assert.True(set.Contains("b"));
         Assert.True(set.Contains("c"));
@@ -509,12 +509,12 @@ public class SetIEnumerableConstructorTests
     [Fact]
     public void CeleritySet_ShouldCaptureNullElement_FromSource()
     {
-        var source = new string?[] { null, "x", "y" };
+        var source = new[] { null!, "x", "y" };
 
-        var set = new CeleritySet<string?, StringFnV1AHasher>(source);
+        var set = new CeleritySet<string, StringFnV1AHasher>(source);
 
         Assert.Equal(3, set.Count);
-        Assert.True(set.Contains(null));
+        Assert.True(set.Contains(null!));
         Assert.True(set.Contains("x"));
         Assert.True(set.Contains("y"));
     }
@@ -662,12 +662,12 @@ public class SetIEnumerableConstructorTests
     [Fact]
     public void SwissSet_ShouldSilentlyDedupe_DuplicateNullElements()
     {
-        var source = new string?[] { "a", null, "b", null, "c", null };
+        var source = new[] { "a", null!, "b", null!, "c", null! };
 
-        var set = new SwissSet<string?, StringFnV1AHasher>(source);
+        var set = new SwissSet<string, StringFnV1AHasher>(source);
 
         Assert.Equal(4, set.Count);
-        Assert.True(set.Contains(null));
+        Assert.True(set.Contains(null!));
         Assert.True(set.Contains("a"));
         Assert.True(set.Contains("b"));
         Assert.True(set.Contains("c"));
@@ -689,12 +689,12 @@ public class SetIEnumerableConstructorTests
     [Fact]
     public void SwissSet_ShouldCaptureNullElement_FromSource()
     {
-        var source = new string?[] { null, "x", "y" };
+        var source = new[] { null!, "x", "y" };
 
-        var set = new SwissSet<string?, StringFnV1AHasher>(source);
+        var set = new SwissSet<string, StringFnV1AHasher>(source);
 
         Assert.Equal(3, set.Count);
-        Assert.True(set.Contains(null));
+        Assert.True(set.Contains(null!));
         Assert.True(set.Contains("x"));
         Assert.True(set.Contains("y"));
     }
@@ -844,12 +844,12 @@ public class SetIEnumerableConstructorTests
     [Fact]
     public void RobinHoodSet_ShouldSilentlyDedupe_DuplicateNullElements()
     {
-        var source = new string?[] { "a", null, "b", null, "c", null };
+        var source = new[] { "a", null!, "b", null!, "c", null! };
 
-        var set = new RobinHoodSet<string?, StringFnV1AHasher>(source);
+        var set = new RobinHoodSet<string, StringFnV1AHasher>(source);
 
         Assert.Equal(4, set.Count);
-        Assert.True(set.Contains(null));
+        Assert.True(set.Contains(null!));
         Assert.True(set.Contains("a"));
         Assert.True(set.Contains("b"));
         Assert.True(set.Contains("c"));
@@ -871,12 +871,12 @@ public class SetIEnumerableConstructorTests
     [Fact]
     public void RobinHoodSet_ShouldCaptureNullElement_FromSource()
     {
-        var source = new string?[] { null, "x", "y" };
+        var source = new[] { null!, "x", "y" };
 
-        var set = new RobinHoodSet<string?, StringFnV1AHasher>(source);
+        var set = new RobinHoodSet<string, StringFnV1AHasher>(source);
 
         Assert.Equal(3, set.Count);
-        Assert.True(set.Contains(null));
+        Assert.True(set.Contains(null!));
         Assert.True(set.Contains("x"));
         Assert.True(set.Contains("y"));
     }
@@ -1026,12 +1026,12 @@ public class SetIEnumerableConstructorTests
     [Fact]
     public void HashCachingSet_ShouldSilentlyDedupe_DuplicateNullElements()
     {
-        var source = new string?[] { "a", null, "b", null, "c", null };
+        var source = new[] { "a", null!, "b", null!, "c", null! };
 
-        var set = new HashCachingSet<string?, StringFnV1AHasher>(source);
+        var set = new HashCachingSet<string, StringFnV1AHasher>(source);
 
         Assert.Equal(4, set.Count);
-        Assert.True(set.Contains(null));
+        Assert.True(set.Contains(null!));
         Assert.True(set.Contains("a"));
         Assert.True(set.Contains("b"));
         Assert.True(set.Contains("c"));
@@ -1053,12 +1053,12 @@ public class SetIEnumerableConstructorTests
     [Fact]
     public void HashCachingSet_ShouldCaptureNullElement_FromSource()
     {
-        var source = new string?[] { null, "x", "y" };
+        var source = new[] { null!, "x", "y" };
 
-        var set = new HashCachingSet<string?, StringFnV1AHasher>(source);
+        var set = new HashCachingSet<string, StringFnV1AHasher>(source);
 
         Assert.Equal(3, set.Count);
-        Assert.True(set.Contains(null));
+        Assert.True(set.Contains(null!));
         Assert.True(set.Contains("x"));
         Assert.True(set.Contains("y"));
     }
@@ -1208,12 +1208,12 @@ public class SetIEnumerableConstructorTests
     [Fact]
     public void PooledCeleritySet_ShouldSilentlyDedupe_DuplicateNullElements()
     {
-        var source = new string?[] { "a", null, "b", null, "c", null };
+        var source = new[] { "a", null!, "b", null!, "c", null! };
 
-        using var set = new PooledCeleritySet<string?, StringFnV1AHasher>(source);
+        using var set = new PooledCeleritySet<string, StringFnV1AHasher>(source);
 
         Assert.Equal(4, set.Count);
-        Assert.True(set.Contains(null));
+        Assert.True(set.Contains(null!));
         Assert.True(set.Contains("a"));
         Assert.True(set.Contains("b"));
         Assert.True(set.Contains("c"));
@@ -1235,12 +1235,12 @@ public class SetIEnumerableConstructorTests
     [Fact]
     public void PooledCeleritySet_ShouldCaptureNullElement_FromSource()
     {
-        var source = new string?[] { null, "x", "y" };
+        var source = new[] { null!, "x", "y" };
 
-        using var set = new PooledCeleritySet<string?, StringFnV1AHasher>(source);
+        using var set = new PooledCeleritySet<string, StringFnV1AHasher>(source);
 
         Assert.Equal(3, set.Count);
-        Assert.True(set.Contains(null));
+        Assert.True(set.Contains(null!));
         Assert.True(set.Contains("x"));
         Assert.True(set.Contains("y"));
     }

--- a/src/Celerity.Tests/Collections/SetIEnumerableConstructorTests.cs
+++ b/src/Celerity.Tests/Collections/SetIEnumerableConstructorTests.cs
@@ -17,6 +17,12 @@ namespace Celerity.Tests.Collections;
 /// </summary>
 public class SetIEnumerableConstructorTests
 {
+    // The hash-table sets reserve an out-of-band null slot and never hash it.
+    // Keep the generic type non-nullable to match StringFnV1AHasher's contract
+    // while deliberately retaining runtime-null test data for that slot.
+    private static string[] CreateSourceWithRuntimeNulls(params string?[] values) =>
+        Array.ConvertAll(values, static value => value!);
+
     // ──────────────────────────────────────────────────────────────
     //  IntSet — source argument validation
     // ──────────────────────────────────────────────────────────────
@@ -480,7 +486,7 @@ public class SetIEnumerableConstructorTests
     public void CeleritySet_ShouldSilentlyDedupe_DuplicateNullElements()
     {
         // null is the out-of-band slot for reference-typed sets — ensure dedupe covers it.
-        var source = new[] { "a", null!, "b", null!, "c", null! };
+        var source = CreateSourceWithRuntimeNulls("a", null, "b", null, "c", null);
 
         var set = new CeleritySet<string, StringFnV1AHasher>(source);
 
@@ -509,7 +515,7 @@ public class SetIEnumerableConstructorTests
     [Fact]
     public void CeleritySet_ShouldCaptureNullElement_FromSource()
     {
-        var source = new[] { null!, "x", "y" };
+        var source = CreateSourceWithRuntimeNulls(null, "x", "y");
 
         var set = new CeleritySet<string, StringFnV1AHasher>(source);
 
@@ -662,7 +668,7 @@ public class SetIEnumerableConstructorTests
     [Fact]
     public void SwissSet_ShouldSilentlyDedupe_DuplicateNullElements()
     {
-        var source = new[] { "a", null!, "b", null!, "c", null! };
+        var source = CreateSourceWithRuntimeNulls("a", null, "b", null, "c", null);
 
         var set = new SwissSet<string, StringFnV1AHasher>(source);
 
@@ -689,7 +695,7 @@ public class SetIEnumerableConstructorTests
     [Fact]
     public void SwissSet_ShouldCaptureNullElement_FromSource()
     {
-        var source = new[] { null!, "x", "y" };
+        var source = CreateSourceWithRuntimeNulls(null, "x", "y");
 
         var set = new SwissSet<string, StringFnV1AHasher>(source);
 
@@ -844,7 +850,7 @@ public class SetIEnumerableConstructorTests
     [Fact]
     public void RobinHoodSet_ShouldSilentlyDedupe_DuplicateNullElements()
     {
-        var source = new[] { "a", null!, "b", null!, "c", null! };
+        var source = CreateSourceWithRuntimeNulls("a", null, "b", null, "c", null);
 
         var set = new RobinHoodSet<string, StringFnV1AHasher>(source);
 
@@ -871,7 +877,7 @@ public class SetIEnumerableConstructorTests
     [Fact]
     public void RobinHoodSet_ShouldCaptureNullElement_FromSource()
     {
-        var source = new[] { null!, "x", "y" };
+        var source = CreateSourceWithRuntimeNulls(null, "x", "y");
 
         var set = new RobinHoodSet<string, StringFnV1AHasher>(source);
 
@@ -1026,7 +1032,7 @@ public class SetIEnumerableConstructorTests
     [Fact]
     public void HashCachingSet_ShouldSilentlyDedupe_DuplicateNullElements()
     {
-        var source = new[] { "a", null!, "b", null!, "c", null! };
+        var source = CreateSourceWithRuntimeNulls("a", null, "b", null, "c", null);
 
         var set = new HashCachingSet<string, StringFnV1AHasher>(source);
 
@@ -1053,7 +1059,7 @@ public class SetIEnumerableConstructorTests
     [Fact]
     public void HashCachingSet_ShouldCaptureNullElement_FromSource()
     {
-        var source = new[] { null!, "x", "y" };
+        var source = CreateSourceWithRuntimeNulls(null, "x", "y");
 
         var set = new HashCachingSet<string, StringFnV1AHasher>(source);
 
@@ -1208,7 +1214,7 @@ public class SetIEnumerableConstructorTests
     [Fact]
     public void PooledCeleritySet_ShouldSilentlyDedupe_DuplicateNullElements()
     {
-        var source = new[] { "a", null!, "b", null!, "c", null! };
+        var source = CreateSourceWithRuntimeNulls("a", null, "b", null, "c", null);
 
         using var set = new PooledCeleritySet<string, StringFnV1AHasher>(source);
 
@@ -1235,7 +1241,7 @@ public class SetIEnumerableConstructorTests
     [Fact]
     public void PooledCeleritySet_ShouldCaptureNullElement_FromSource()
     {
-        var source = new[] { null!, "x", "y" };
+        var source = CreateSourceWithRuntimeNulls(null, "x", "y");
 
         using var set = new PooledCeleritySet<string, StringFnV1AHasher>(source);
 


### PR DESCRIPTION
## Summary

- Treat warnings as errors in `Celerity.Tests`.
- Suppress only `xUnit2013`, `xUnit2017`, and `xUnit2027`, with a comment explaining that the existing assertions must exercise each collection's own `Contains` and `Count` paths.
- Keep null-source constructor coverage while matching the non-nullable `StringFnV1AHasher` contract, eliminating the real `CS8631`/`CS8625` warnings.

## Root cause

The test project accumulated analyzer warnings while real compiler nullability warnings were hidden in the same output. The nullable string tests instantiated collections with a hasher that intentionally implements `IHashProvider<string>`, not `IHashProvider<string?>`.

## Validation

- `dotnet build src/Celerity.Tests/Celerity.Tests.csproj --no-restore` (0 warnings, 0 errors across net8.0/net9.0/net10.0)
- `dotnet test src/Celerity.Tests/Celerity.Tests.csproj --no-build --no-restore -f net10.0 -v:minimal` (5,604 passed)

Net8.0 and net9.0 test execution remains unavailable locally because their runtimes are not installed; both targets compile cleanly.

Closes #332.