### PR TITLE
fix(docs): stop MaxMonoid shipping with no documentation at all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to Celerity are documented here. This project follows [Keep 
 
 ## [Unreleased]
 
+### Added
+
+- **CS1570 (badly formed XML in a doc comment) is now a build error** in all seven shipping packages, alongside the existing CS1591 gate. A malformed comment is not truncated by the doc writer — the whole member is dropped from the shipped `.xml` — so a warning was too weak a signal. Closes [#356](https://github.com/marius-bughiu/Celerity/issues/356).
+- `XmlDocumentationTests` — asserts each shipped `.xml` parses and carries an entry for every public type of its assembly, so a type cannot silently lose its documentation again. Closes [#356](https://github.com/marius-bughiu/Celerity/issues/356).
+
+### Fixed
+
+- `MaxMonoid<T>` shipped with **no XML documentation at all**: an unclosed `<para>` made the doc writer drop the entire type entry, so IDE tooltips and generated reference pages showed nothing — including the floating-point caveat that a `-∞` aggregates to `T.MinValue` and that `NaN` resolves by operand position. Closes [#356](https://github.com/marius-bughiu/Celerity/issues/356).
+
 ## [2.6.0] - 2026-08-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to Celerity are documented here. This project follows [Keep 
 
 ### Added
 
-- **CS1570 (badly formed XML in a doc comment) is now a build error** in all seven shipping packages, alongside the existing CS1591 gate, and each package's shipped `.xml` is asserted to carry an entry for every public type. A malformed comment is not truncated by the doc writer — the whole member is dropped — so a warning was too weak a signal for something that silently empties a type's documentation. Closes [#356](https://github.com/marius-bughiu/Celerity/issues/356).
+- **CS1570 (badly formed XML in a doc comment) is now a build error** in all seven shipping packages, alongside the existing CS1591 gate, backed by a test that reads the shipped `.xml` back and asserts an entry for every public type. A malformed comment is not truncated by the doc writer — the whole member is dropped — so a warning was too weak a signal for something that silently empties a type's documentation. Closes [#356](https://github.com/marius-bughiu/Celerity/issues/356).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,7 @@ All notable changes to Celerity are documented here. This project follows [Keep 
 
 ### Added
 
-- **CS1570 (badly formed XML in a doc comment) is now a build error** in all seven shipping packages, alongside the existing CS1591 gate. A malformed comment is not truncated by the doc writer — the whole member is dropped from the shipped `.xml` — so a warning was too weak a signal. Closes [#356](https://github.com/marius-bughiu/Celerity/issues/356).
-- `XmlDocumentationTests` — asserts each shipped `.xml` parses and carries an entry for every public type of its assembly, so a type cannot silently lose its documentation again. Closes [#356](https://github.com/marius-bughiu/Celerity/issues/356).
+- **CS1570 (badly formed XML in a doc comment) is now a build error** in all seven shipping packages, alongside the existing CS1591 gate, and each package's shipped `.xml` is asserted to carry an entry for every public type. A malformed comment is not truncated by the doc writer — the whole member is dropped — so a warning was too weak a signal for something that silently empties a type's documentation. Closes [#356](https://github.com/marius-bughiu/Celerity/issues/356).
 
 ### Fixed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ dotnet test                  # xUnit
 
 - `net8.0` is the floor. Shared code must not use net9/net10-only APIs unguarded — gate newer paths with `#if NET9_0_OR_GREATER` / `NET10_0_OR_GREATER` and keep a net8.0 fallback. The target list lives in `src/Directory.Build.props`.
 - Coverage is gated in CI at 100% line and 100% branch across all six shipping packages. New code needs its tests. For a branch no test can reach, use `[ExcludeFromCodeCoverage(Justification = "…")]` rather than lowering the floor, and add a new shipping package's assembly to `src/coverage.runsettings` (the filter is exact-match, so an unlisted package is silently unmeasured).
-- Every public type/member needs an XML doc comment (`GenerateDocumentationFile` is on; missing docs warn).
+- Every public type/member needs an XML doc comment that is also well-formed XML. `GenerateDocumentationFile` is on and every shipping package promotes CS1591 (missing) and CS1570 (badly formed) to build errors — a stray unclosed tag makes the doc writer drop the whole member from the shipped `.xml`, not truncate it.
 - Hashers are `struct`s passed as generic constraints (`where THasher : struct, IHashProvider<T>`) so the JIT devirtualizes them — do not turn them into classes/interfaces.
 - Avoid allocations on hot paths.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ These are enforced by review, not by an analyzer. Reading the existing code is t
 - The packages multi-target `net8.0;net9.0;net10.0` (the shared list lives in [`src/Directory.Build.props`](src/Directory.Build.props); bump it there). `net8.0` is the lowest target, so shared code must not use net9/net10-only APIs unguarded — gate any newer-runtime path with `#if NET9_0_OR_GREATER` / `NET10_0_OR_GREATER` and keep a net8.0 fallback. Nullable reference types are enabled.
 - File-scoped namespaces (`namespace Celerity.Hashing;`).
 - `PascalCase` for public members, `_camelCase` for private fields, `UPPER_CASE` for constants.
-- Every public type and member has an XML doc comment. `GenerateDocumentationFile` is on, so missing docs produce warnings.
+- Every public type and member has an XML doc comment. `GenerateDocumentationFile` is on and every shipping package promotes both **CS1591** (missing doc comment) and **CS1570** (badly formed XML in a doc comment) to build errors, so a doc comment must be present *and* parse. The second gate matters because the doc writer drops the whole member element rather than truncating it, so a stray unclosed tag ships a type with no documentation at all.
 - Hash providers are structs that implement `IHashProvider<T>`. This is load-bearing: passing them as a generic constraint (`where THasher : struct, IHashProvider<T>`) lets the JIT devirtualize `hasher.Hash(...)` calls. Please do not change them to classes or interfaces.
 - Prefer explicit types over `var` where it meaningfully helps readability (e.g. in tight numeric loops). Use `var` freely for obvious right-hand-sides.
 - Avoid allocations on hot paths. If you add a new dependency or a LINQ call inside a probe loop, expect pushback.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -75,7 +75,7 @@ The next release rounds out the `Celerity.Collections` package with missing coll
 - Cross-platform testing (Windows, Linux, macOS). Status: `done`.
 - Improve code coverage. Status: `done` — coverage reporting is gated in CI (`coverage.yml`, 100% line coverage on the library, rendered by an in-repo generator and published to the [coverage dashboard](https://marius-bughiu.github.io/Celerity/coverage/)), edge-case tests close the non-generic enumerator / throw / backward-shift corners, property-based parity tests (CsCheck) and a seedable differential fuzzer (`Celerity.Fuzz`, nightly soak) check every collection against its BCL oracle, and the approach is written up in [`docs/testing.md`](docs/testing.md). Tracked in [#29](https://github.com/marius-bughiu/Celerity/issues/29).
 - Improve documentation. Status: `done` — added a performance tuning guide, a BCL migration guide, a troubleshooting guide, and a FAQ, alongside the existing README usage examples, "choosing a collection" table, and API reference. Tracked in [#15](https://github.com/marius-bughiu/Celerity/issues/15).
-- Bump XML doc coverage; treat missing docs as warning-as-error. Status: `done` — `Celerity.csproj` promotes CS1591 to error.
+- Bump XML doc coverage; treat missing docs as warning-as-error. Status: `done` — every shipping package promotes CS1591 (missing doc comment) to error, and since [#356](https://github.com/marius-bughiu/Celerity/issues/356) CS1570 (badly formed XML in a doc comment) as well, so a doc comment must be present *and* parse.
 
 ## Milestone 1.2.0 — Performance & advanced collections
 

--- a/src/Celerity.Cardinality/Celerity.Cardinality.csproj
+++ b/src/Celerity.Cardinality/Celerity.Cardinality.csproj
@@ -16,10 +16,12 @@
 		-->
 		<IsAotCompatible>true</IsAotCompatible>
 		<!--
-		  Promote CS1591 (missing XML comment) to error. Every public symbol in the
-		  package must carry an XML doc comment so the shipped .xml is complete.
+		  Promote CS1591 (missing XML comment) and CS1570 (badly formed XML in a doc
+		  comment) to errors. Every public symbol in the package must carry an XML doc
+		  comment and that comment must parse, so the shipped .xml is complete: the doc
+		  writer silently drops the whole member when its comment is not well formed.
 		-->
-		<WarningsAsErrors>$(WarningsAsErrors);CS1591</WarningsAsErrors>
+		<WarningsAsErrors>$(WarningsAsErrors);CS1591;CS1570</WarningsAsErrors>
 		<PackageId>Celerity.Cardinality</PackageId>
 		<Description>Mergeable, deterministic distinct-count (approximate COUNT DISTINCT) over managed streams: an exact small-N fast path that promotes to a fixed ~16 KB HyperLogLog past a threshold, plus a removable Cuckoo dedup filter for windowed exact-ish deduplication. Generic over the caller's key type and a zero-cost inlined Celerity hasher, with cross-shard merge that is byte-identical across runtimes. Built on Celerity.Collections.</Description>
 		<PackageIcon>icon.png</PackageIcon>

--- a/src/Celerity.Hashing/Celerity.Hashing.csproj
+++ b/src/Celerity.Hashing/Celerity.Hashing.csproj
@@ -16,10 +16,12 @@
 		-->
 		<IsAotCompatible>true</IsAotCompatible>
 		<!--
-		  Promote CS1591 (missing XML comment) to error. Every public symbol in the
-		  package must carry an XML doc comment so the shipped .xml is complete.
+		  Promote CS1591 (missing XML comment) and CS1570 (badly formed XML in a doc
+		  comment) to errors. Every public symbol in the package must carry an XML doc
+		  comment and that comment must parse, so the shipped .xml is complete: the doc
+		  writer silently drops the whole member when its comment is not well formed.
 		-->
-		<WarningsAsErrors>$(WarningsAsErrors);CS1591</WarningsAsErrors>
+		<WarningsAsErrors>$(WarningsAsErrors);CS1591;CS1570</WarningsAsErrors>
 		<PackageId>Celerity.Hashing</PackageId>
 		<Description>Zero-cost struct hash providers and hash-quality tooling: IHashProvider&lt;T&gt;, integer/string/Guid hashers (identity, Wang, Murmur3, xxHash, SipHash, ...), DefaultHasher&lt;T&gt;, and the HashQualityEvaluator / ProbeStatisticsEvaluator offline analysis utilities. Positioned on distribution quality, determinism, and devirtualization — not on beating GetHashCode() for speed. Part of the Celerity family.</Description>
 		<PackageIcon>icon.png</PackageIcon>

--- a/src/Celerity.Primitives/Celerity.Primitives.csproj
+++ b/src/Celerity.Primitives/Celerity.Primitives.csproj
@@ -16,10 +16,12 @@
 		-->
 		<IsAotCompatible>true</IsAotCompatible>
 		<!--
-		  Promote CS1591 (missing XML comment) to error. Every public symbol in the
-		  package must carry an XML doc comment so the shipped .xml is complete.
+		  Promote CS1591 (missing XML comment) and CS1570 (badly formed XML in a doc
+		  comment) to errors. Every public symbol in the package must carry an XML doc
+		  comment and that comment must parse, so the shipped .xml is complete: the doc
+		  writer silently drops the whole member when its comment is not well formed.
 		-->
-		<WarningsAsErrors>$(WarningsAsErrors);CS1591</WarningsAsErrors>
+		<WarningsAsErrors>$(WarningsAsErrors);CS1591;CS1570</WarningsAsErrors>
 		<PackageId>Celerity.Primitives</PackageId>
 		<Description>Low-level, allocation-free primitives that fill genuine BCL gaps: Lemire FastMod/FastDiv, struct PRNGs (xoshiro/xoroshiro/SplitMix64/wyrand/PCG), span LEB128/zig-zag varint codec, integer digit-count/Log10, fast non-crypto GUID v4 / RFC 9562 big-endian v7, fused/specialized SIMD reductions (single-pass MinMax, overflow-checked sum), guaranteed branch-free conditional select, and merge-based set algebra over sorted spans. Part of the Celerity family.</Description>
 		<PackageIcon>icon.png</PackageIcon>

--- a/src/Celerity.Ring/Celerity.Ring.csproj
+++ b/src/Celerity.Ring/Celerity.Ring.csproj
@@ -16,10 +16,12 @@
 		-->
 		<IsAotCompatible>true</IsAotCompatible>
 		<!--
-		  Promote CS1591 (missing XML comment) to error. Every public symbol in the
-		  package must carry an XML doc comment so the shipped .xml is complete.
+		  Promote CS1591 (missing XML comment) and CS1570 (badly formed XML in a doc
+		  comment) to errors. Every public symbol in the package must carry an XML doc
+		  comment and that comment must parse, so the shipped .xml is complete: the doc
+		  writer silently drops the whole member when its comment is not well formed.
 		-->
-		<WarningsAsErrors>$(WarningsAsErrors);CS1591</WarningsAsErrors>
+		<WarningsAsErrors>$(WarningsAsErrors);CS1591;CS1570</WarningsAsErrors>
 		<PackageId>Celerity.Ring</PackageId>
 		<Description>Deterministic consistent-hashing and rendezvous (HRW) rings for sharding and request routing, generic over the caller's key type and a zero-cost inlined Celerity hasher. Fills a literal BCL gap (there is no ConsistentHashRing in .NET) and produces byte-identical shard assignments across runtimes and architectures (x64 / arm64 / Blazor WASM). Part of the Celerity family.</Description>
 		<PackageIcon>icon.png</PackageIcon>

--- a/src/Celerity.Sentinel/Celerity.Sentinel.csproj
+++ b/src/Celerity.Sentinel/Celerity.Sentinel.csproj
@@ -16,10 +16,12 @@
 		-->
 		<IsAotCompatible>true</IsAotCompatible>
 		<!--
-		  Promote CS1591 (missing XML comment) to error. Every public symbol in the
-		  package must carry an XML doc comment so the shipped .xml is complete.
+		  Promote CS1591 (missing XML comment) and CS1570 (badly formed XML in a doc
+		  comment) to errors. Every public symbol in the package must carry an XML doc
+		  comment and that comment must parse, so the shipped .xml is complete: the doc
+		  writer silently drops the whole member when its comment is not well formed.
 		-->
-		<WarningsAsErrors>$(WarningsAsErrors);CS1591</WarningsAsErrors>
+		<WarningsAsErrors>$(WarningsAsErrors);CS1591;CS1570</WarningsAsErrors>
 		<PackageId>Celerity.Sentinel</PackageId>
 		<Description>Streaming abuse / heavy-hitter detection in fixed memory: a single Observe(key) fans a request key into a Count-Min rate sketch, a Space-Saving top-offenders sketch, a HyperLogLog distinct-volume estimator, and a Bloom first-seen filter — all bounded so an attacker rotating keys cannot grow it unbounded. Generic over the caller's key type and a zero-cost inlined Celerity hasher, mergeable for per-core striping and fleet rollup. Built on Celerity.Collections.</Description>
 		<PackageIcon>icon.png</PackageIcon>

--- a/src/Celerity.Sorting/Celerity.Sorting.csproj
+++ b/src/Celerity.Sorting/Celerity.Sorting.csproj
@@ -16,10 +16,12 @@
 		-->
 		<IsAotCompatible>true</IsAotCompatible>
 		<!--
-		  Promote CS1591 (missing XML comment) to error. Every public symbol in the
-		  package must carry an XML doc comment so the shipped .xml is complete.
+		  Promote CS1591 (missing XML comment) and CS1570 (badly formed XML in a doc
+		  comment) to errors. Every public symbol in the package must carry an XML doc
+		  comment and that comment must parse, so the shipped .xml is complete: the doc
+		  writer silently drops the whole member when its comment is not well formed.
 		-->
-		<WarningsAsErrors>$(WarningsAsErrors);CS1591</WarningsAsErrors>
+		<WarningsAsErrors>$(WarningsAsErrors);CS1591;CS1570</WarningsAsErrors>
 		<PackageId>Celerity.Sorting</PackageId>
 		<Description>Non-comparison sorts and selection over primitive keys: LSD RadixSort for (u)int/(u)long/float/double with key+payload and key+index (argsort) forms, CountingSort for bounded key ranges, and PartialSort quickselect / bounded-heap top-k. Span-based, with caller-supplied-scratch overloads that allocate nothing. Every entry point documents the crossover below which Array.Sort wins. Part of the Celerity family.</Description>
 		<PackageIcon>icon.png</PackageIcon>

--- a/src/Celerity.Tests/Packaging/XmlDocumentationTests.cs
+++ b/src/Celerity.Tests/Packaging/XmlDocumentationTests.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Xml.Linq;
+using Celerity.Collections;
+using Celerity.Hashing;
+using Celerity.Primitives;
+using Celerity.Sorting;
+using Xunit;
+
+namespace Celerity.Tests.Packaging;
+
+/// <summary>
+/// Guards the XML documentation file each package ships alongside its assembly (#356).
+/// <para>
+/// A doc comment that is not well-formed XML does not reach the consumer in truncated form — the doc
+/// writer drops the <em>entire</em> member element, so the type loses its summary and remarks in every
+/// IDE tooltip and generated reference page while the build still succeeds. That is how
+/// <see cref="MaxMonoid{T}"/> shipped with no documentation at all: an unclosed <c>&lt;para&gt;</c>
+/// produced two CS1570 warnings that were easy to scroll past.
+/// </para>
+/// <para>
+/// The shipping packages now promote CS1570 to an error, which stops the same slip at the compiler.
+/// These tests close the loop from the other end, asserting against the artifact that actually ships:
+/// every public type this test project can reach must be present in its package's <c>.xml</c>.
+/// The three showcase packages (<c>Celerity.Ring</c>, <c>Celerity.Sentinel</c>,
+/// <c>Celerity.Cardinality</c>) are not referenced from here and rely on the same compiler gate.
+/// </para>
+/// </summary>
+public class XmlDocumentationTests
+{
+    /// <summary>One anchor type per shipping assembly reachable from this test project.</summary>
+    private static readonly Type[] AssemblyAnchors =
+    [
+        typeof(BitSet),             // Celerity            (package Celerity.Collections)
+        typeof(IHashProvider<int>), // Celerity.Hashing
+        typeof(FastUtils),          // Celerity.Primitives
+        typeof(RadixSort),          // Celerity.Sorting
+    ];
+
+    public static TheoryData<string> ShippingAssemblies
+    {
+        get
+        {
+            var data = new TheoryData<string>();
+
+            foreach (var anchor in AssemblyAnchors)
+                data.Add(anchor.Assembly.GetName().Name!);
+
+            return data;
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(ShippingAssemblies))]
+    public void DocumentationFile_ShouldParseAsWellFormedXml_WhenShippedWithTheAssembly(string assemblyName)
+    {
+        var path = DocumentationPathFor(assemblyName);
+
+        Assert.True(File.Exists(path), $"{assemblyName} ships no XML documentation file at '{path}'.");
+
+        var exception = Record.Exception(() => XDocument.Load(path));
+
+        Assert.Null(exception);
+    }
+
+    [Theory]
+    [MemberData(nameof(ShippingAssemblies))]
+    public void DocumentationFile_ShouldDescribeEveryPublicType_WhenShippedWithTheAssembly(string assemblyName)
+    {
+        var assembly = AssemblyNamed(assemblyName);
+        var documented = DocumentedMemberIds(assemblyName);
+
+        var undocumented = PublicTypesOf(assembly)
+            .Select(DocumentationIdOf)
+            .Where(id => !documented.Contains(id))
+            .OrderBy(id => id, StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.True(
+            undocumented.Length == 0,
+            $"{assemblyName}.xml is missing an entry for {undocumented.Length} public type(s). A doc "
+                + "comment that is not well-formed XML is dropped whole rather than truncated: "
+                + string.Join(", ", undocumented));
+    }
+
+    [Fact]
+    public void MaxMonoid_ShouldShipItsSummaryAndRemarks_WhenTheDocumentationFileIsGenerated()
+    {
+        var id = DocumentationIdOf(typeof(MaxMonoid<>));
+        var member = MemberElement("Celerity", id);
+
+        Assert.NotNull(member);
+        Assert.False(string.IsNullOrWhiteSpace(member!.Element("summary")?.Value));
+
+        var remarks = member.Element("remarks");
+
+        Assert.NotNull(remarks);
+
+        // The floating-point caveat is the one thing a caller most needs from this type, and it sat in
+        // the <para> the unclosed tag took with it.
+        Assert.Contains("NaN", remarks!.Value, StringComparison.Ordinal);
+    }
+
+    private static Assembly AssemblyNamed(string name) =>
+        AssemblyAnchors.Select(anchor => anchor.Assembly).First(a => a.GetName().Name == name);
+
+    private static string DocumentationPathFor(string assemblyName) =>
+        Path.ChangeExtension(AssemblyNamed(assemblyName).Location, ".xml");
+
+    /// <summary>
+    /// The public types an assembly declares. <see cref="Assembly.GetExportedTypes"/> also reports the
+    /// types the 2.0.0 split forwards on to a lower package, and those are documented where they are
+    /// declared, so they are filtered out here.
+    /// </summary>
+    private static IEnumerable<Type> PublicTypesOf(Assembly assembly) =>
+        assembly.GetExportedTypes().Where(t => t.Assembly == assembly);
+
+    /// <summary>
+    /// The ID the compiler writes for a type: the metadata name with nested types joined by <c>.</c>
+    /// rather than reflection's <c>+</c>, prefixed by <c>T:</c>.
+    /// </summary>
+    private static string DocumentationIdOf(Type type) => "T:" + type.FullName!.Replace('+', '.');
+
+    private static HashSet<string> DocumentedMemberIds(string assemblyName) =>
+        XDocument.Load(DocumentationPathFor(assemblyName))
+            .Descendants("member")
+            .Select(m => (string?)m.Attribute("name"))
+            .Where(name => name is not null)
+            .Select(name => name!)
+            .ToHashSet(StringComparer.Ordinal);
+
+    private static XElement? MemberElement(string assemblyName, string id) =>
+        XDocument.Load(DocumentationPathFor(assemblyName))
+            .Descendants("member")
+            .FirstOrDefault(m => (string?)m.Attribute("name") == id);
+}

--- a/src/Celerity/Celerity.csproj
+++ b/src/Celerity/Celerity.csproj
@@ -20,12 +20,15 @@
 		<IsAotCompatible>true</IsAotCompatible>
 		<!--
 		  Promote CS1591 (missing XML comment for publicly visible type or member)
-		  from warning to error. Celerity is a public NuGet package; every public
-		  symbol must carry an XML doc comment so the generated .xml shipping in
-		  the package is complete. The library is at 100% public-symbol doc
-		  coverage today and this gate keeps it that way.
+		  and CS1570 (badly formed XML in a doc comment) from warning to error.
+		  Celerity is a public NuGet package; every public symbol must carry an XML
+		  doc comment, and that comment must parse, so the generated .xml shipping in
+		  the package is complete. A comment that is not well formed is not truncated
+		  by the doc writer, it is dropped whole, taking the member's summary with it,
+		  which is why a warning is not a strong enough signal here. The library is at
+		  100% public-symbol doc coverage today and this gate keeps it that way.
 		-->
-		<WarningsAsErrors>$(WarningsAsErrors);CS1591</WarningsAsErrors>
+		<WarningsAsErrors>$(WarningsAsErrors);CS1591;CS1570</WarningsAsErrors>
 		<PackageId>Celerity.Collections</PackageId>
 		<RepositoryUrl>https://github.com/marius-bughiu/Celerity</RepositoryUrl>
 		<Description>High-performance .NET dictionaries, sets, frozen/perfect-hash collections, and probabilistic sketches (Bloom, HyperLogLog, Count-Min) built on zero-cost struct hashers. As of the 2.0.0 split this package transitively pulls in Celerity.Hashing and Celerity.Primitives, so existing consumers keep working unchanged.</Description>

--- a/src/Celerity/Collections/MaxMonoid.cs
+++ b/src/Celerity/Collections/MaxMonoid.cs
@@ -18,6 +18,7 @@ namespace Celerity.Collections;
 /// reversed: the identity is <c>T.MinValue</c>, the smallest <i>finite</i> value, so a stored <c>-∞</c>
 /// aggregates to <c>T.MinValue</c>; and <c>NaN</c> loses every <c>&gt;</c> comparison, so it is discarded from
 /// the left operand and kept from the right.
+/// </para>
 /// </remarks>
 public readonly struct MaxMonoid<T> : IMonoid<T>
     where T : struct, INumber<T>, IMinMaxValue<T>


### PR DESCRIPTION
Closes #356.

## The defect was worse than filed

The issue reported that `MaxMonoid<T>`'s unclosed `<para>` put its **remarks** at risk. Checking the generated `Celerity.xml` on `main`, the damage is total — the member element is absent entirely:

```
MEMBER: P:Celerity.Collections.MaxMonoid`1.Identity
MEMBER: M:Celerity.Collections.MaxMonoid`1.Combine(`0,`0)
--- MinMonoid for contrast ---
MEMBER: T:Celerity.Collections.MinMonoid`1        <-- present
MEMBER: P:Celerity.Collections.MinMonoid`1.Identity
MEMBER: M:Celerity.Collections.MinMonoid`1.Combine(`0,`0)
```

There is no `T:Celerity.Collections.MaxMonoid`1` entry. The doc writer does not truncate a malformed comment, it drops the whole member — so the type shipped with **no summary, no `typeparam`, and no remarks**, and an IDE tooltip on `MaxMonoid<T>` shows nothing. The floating-point caveat (a stored `-∞` aggregates to `T.MinValue`; `NaN` resolves by operand position) was already gone, not merely at risk.

## What changed

**Fix** — `src/Celerity/Collections/MaxMonoid.cs`: one `</para>`. The `T:` entry is back in the shipped XML with its summary, `typeparam` and both `<para>` blocks. No behavioural change.

**Compiler gate** — CS1570 joins CS1591 in `<WarningsAsErrors>` across all seven shipping packages (`Celerity`, `Celerity.Hashing`, `Celerity.Primitives`, `Celerity.Sorting`, `Celerity.Ring`, `Celerity.Sentinel`, `Celerity.Cardinality`). A doc comment must now be present *and* parse. Verified by rebuilding against the original comment: the two warnings become

```
error CS1570: XML comment has badly formed XML -- 'End tag 'remarks' does not match the start tag 'para'.'
error CS1570: XML comment has badly formed XML -- 'Expected an end tag for element 'remarks'.'
```

**Regression test** — `src/Celerity.Tests/Packaging/XmlDocumentationTests.cs` asserts against the artifact that actually ships, not the source:

- `DocumentationFile_ShouldParseAsWellFormedXml_...` — each package's `.xml` loads.
- `DocumentationFile_ShouldDescribeEveryPublicType_...` — every public type the assembly *declares* (forwarded types are filtered out, since they are documented where they are declared) has a `<member name="T:…">` entry.
- `MaxMonoid_ShouldShipItsSummaryAndRemarks_...` — pins the specific entry, including the `NaN` caveat.

Both of the latter two fail on the pre-fix comment, with the assembly-wide one naming the culprit:

```
Celerity.xml is missing an entry for 1 public type(s). A doc comment that is not
well-formed XML is dropped whole rather than truncated: T:Celerity.Collections.MaxMonoid`1
```

It covers the four packages this test project reaches; the three showcase packages are not referenced from here and rely on the compiler gate.

**Docs** — `CONTRIBUTING.md`, `CLAUDE.md` and the `ROADMAP.md` doc-coverage line each described the CS1591 gate alone and are updated to cover both, with the reason the second one is needed. `CHANGELOG.md` gets `### Added` bullets for the gate and the tests, and a `### Fixed` bullet for the defect.

## Parity checklist

| Facet | Status |
|---|---|
| Dedicated tests | `XmlDocumentationTests` (9 cases) |
| Cross-collection shared suites | **n/a** — no new type; the existing suites have no row shape for a doc-comment fix |
| Benchmark + `Program.cs` | **n/a** — no code path changed. A doc comment and an MSBuild property cannot move a measured number. The sharded run still fires: `scripts/benchmark_relevant_changes.js` only proves comment-only `.cs` edits inert, and this diff touches `.csproj` files, which it treats as significant by design |
| Dashboard wiring (`web/…`) | **n/a** — no new collection, so no `COLLECTIONS` entry or ship card |
| `docs/api/collections.md` | already correct — the prose carries the floating-point caveat independently of the XML comment, so only the shipped `.xml` was wrong. `README.md` likewise needs no change |
| `CHANGELOG.md` | added |
| `ROADMAP.md` | doc-coverage line updated to name both gates |

## Test plan

- [x] `dotnet build --no-incremental` — 0 warnings, 0 errors (Debug and Release).
- [x] `dotnet test` on **net8.0 / net9.0 / net10.0** — 5658 passed, 0 failed each.
- [x] Showcase suites: `Celerity.Ring.Tests` 46, `Celerity.Sentinel.Tests` 30, `Celerity.Cardinality.Tests` 37 — all pass, confirming the CS1570 promotion breaks nothing in those packages.
- [x] Reverted `MaxMonoid.cs` and rebuilt: CS1570 fires as an **error**, and the two new tests **fail** — the gate and the regression test both bite.
- [x] `node scripts/check_doc_anchors.js` — 585 links across 23 markdown files resolve.
- [ ] CI matrix (ubuntu / windows / macos × net8.0 / net9.0 / net10.0), coverage gate, AOT smoke test, package-validation gate.
- [x] Copilot review loop: 3 rounds. Round 1 raised one changelog-style comment (folded, replied, thread resolved); round 2 suppressed one comment flagging that my fold overclaimed the test's package coverage (corrected in 8667ab5, answered in a PR comment since suppressed comments open no thread); round 3 came back with nothing.
- [ ] No gh-pages dashboard refresh is expected on merge — this PR adds no benchmark and changes no measured code path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

