### PR TITLE
Perform the post-v2.6.0 package-validation ritual

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -211,7 +211,7 @@ The workflow extracts the `## [X.Y.Z]` section of `CHANGELOG.md` and uses it as 
 
 Every `dotnet pack` validates each package against its last published version and **fails the build on any breaking API change**, across all three TFMs. Since the NuGet push is irreversible, this guard has to run before it — so it runs on every release build, and locally whenever you pack.
 
-The baseline is one property, `<CelerityPackageValidationBaseline>` in `src/Directory.Build.props`, shared by every package that has shipped at least once — six of the seven today, since `Celerity.Sorting` is still on the first-release escape hatch below. **Bump it to X.Y.Z in a follow-up commit, once vX.Y.Z is published and indexed on NuGet.org** — not in the release commit itself, because the value becomes a `PackageDownload` and a version that is not published yet fails the release build's restore. This is the part that rots: a stale baseline keeps validating against an older surface, so a break introduced after it slips through.
+The baseline is one property, `<CelerityPackageValidationBaseline>` in `src/Directory.Build.props`, shared by every package that has shipped at least once — all seven today, now that `Celerity.Sorting` has had its first release and come off the escape hatch below. **Bump it to X.Y.Z in a follow-up commit, once vX.Y.Z is published and indexed on NuGet.org** — not in the release commit itself, because the value becomes a `PackageDownload` and a version that is not published yet fails the release build's restore. This is the part that rots: a stale baseline keeps validating against an older surface, so a break introduced after it slips through.
 
 Two situations need a deliberate decision rather than a workaround:
 

--- a/src/Celerity.Sorting/Celerity.Sorting.csproj
+++ b/src/Celerity.Sorting/Celerity.Sorting.csproj
@@ -27,13 +27,6 @@
 		<PackageIcon>icon.png</PackageIcon>
 		<PackageTags>celerity;sorting;radix-sort;counting-sort;quickselect;top-k;argsort;span;performance</PackageTags>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
-		<!--
-		  First release: no published predecessor exists on NuGet.org, so asking for a
-		  package-validation baseline fails restore. See Directory.Build.targets — drop
-		  this property once Celerity.Sorting has shipped once and the baseline in
-		  Directory.Build.props names a version that contains it.
-		-->
-		<CelerityNoPublishedBaseline>true</CelerityNoPublishedBaseline>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -109,7 +109,7 @@
     IsPackable is known; see the comment there.
   -->
   <PropertyGroup>
-    <CelerityPackageValidationBaseline>2.5.0</CelerityPackageValidationBaseline>
+    <CelerityPackageValidationBaseline>2.6.0</CelerityPackageValidationBaseline>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
## What

Performs the post-release package-validation ritual that v2.6.0 skipped, in the two coupled places it lives. `CelerityPackageValidationBaseline` in `src/Directory.Build.props` moves from `2.5.0` to `2.6.0`, and `Celerity.Sorting.csproj` drops `CelerityNoPublishedBaseline`, the first-release escape hatch it has carried since the package was introduced. The two changes have to land in the same commit: `Celerity.Sorting` has no `2.5.0` on NuGet.org — `2.6.0` is its first stable release — so dropping the escape hatch while the shared baseline still read `2.5.0` would fail its restore.

## Why

`v2.6.0` is tagged, published, and indexed on NuGet.org for all seven packages, but the follow-up commit that `Directory.Build.props` and `CONTRIBUTING.md` both describe never landed. This is precisely the failure mode the comment in `Directory.Build.props` warns about — *"This is the part that rots: a stale baseline silently validates against an older surface, so a break introduced after it goes unnoticed."*

Two gaps were open as a result:

- Every package was validating its surface against its **2.5.0** predecessor, so any binary break introduced *in* 2.6.0 would pack green. The push to NuGet.org is irreversible, which is why the gate has to run before it.
- `Celerity.Sorting` had **no baseline at all**. `PackageValidationBaselineVersion` is set only when `CelerityNoPublishedBaseline != 'true'`, so the package that shipped most recently was the one package entirely outside the compatibility gate.

## Test plan

- [x] `dotnet pack -c Release` on all seven shipping packages — every one restores its `2.6.0` baseline and validates clean, no `PKV` diagnostics.
- [x] `Celerity.Sorting/obj/project.assets.json` now carries the `Celerity.Sorting [2.6.0, 2.6.0]` `PackageDownload` on `net8.0`, `net9.0` and `net10.0`, where it previously had none — confirming validation is actually engaged rather than silently skipped.
- [x] No source, API surface, or behaviour change; build-configuration only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
