### PR TITLE
docs(sentinel): document AbuseTrackerOptions in the package README

### DIFF
--- a/src/Celerity.Sentinel/README.md
+++ b/src/Celerity.Sentinel/README.md
@@ -45,6 +45,27 @@ Generic over any key type:
 var byId = new AbuseTracker<long, Int64WangNaiveHasher>();
 ```
 
+## Tuning
+
+Every knob lives on `AbuseTrackerOptions`, accepted by each tracker constructor. Each one sizes a fixed
+structure, so the whole footprint is chosen here and then never grows with key cardinality:
+
+```csharp
+var sentinel = new StringAbuseTracker(new AbuseTrackerOptions
+{
+    RateEpsilon = 0.001,              // Count-Min relative error; smaller widens the sketch
+    RateConfidence = 0.99,            // chance a rate estimate stays inside that bound
+    OffenderCapacity = 128,           // Space-Saving k — the divisor in the table above
+    DistinctPrecision = 14,           // HyperLogLog registers: 2^14 bytes ≈ 16 KB, ≈0.8% error
+    TrackFirstSeen = true,            // maintain the Bloom first-seen filter
+    ExpectedDistinctKeys = 1_000_000, // what that filter is sized for
+    FirstSeenFalsePositiveRate = 0.01,
+});
+```
+
+Those are the defaults, so `new StringAbuseTracker()` is the block above. Two trackers must be built with
+equal options to `Merge`, since a merge combines the underlying sketches and needs identical geometry.
+
 ## Concurrency: per-core striping + merge
 
 A single tracker is single-threaded (like every Celerity collection). For real edge QPS, use `StripedAbuseTracker` — independent lanes with no lock on the observe path, rolled up on demand:


### PR DESCRIPTION
## What

Adds a short **Tuning** section to `src/Celerity.Sentinel/README.md` naming `AbuseTrackerOptions`, showing all seven knobs with their actual default values, and stating that two trackers need equal options to `Merge`. Documentation only — no source, no API, no test changes.

## Why

The README already tunes against this type without ever introducing it. Its guarantee table cites `` `Total / OffenderCapacity` `` as the threshold above which the offender sketch never misses a key, and the opening claim is that the tracker is "sized **once** (a couple of MB at the defaults)" — but a reader has no way to discover that `OffenderCapacity` is a property, which type carries it, what the defaults are, or how to change any of it.

Two things make this more than a nice-to-have:

- Sweeping all 152 public types in the eight shipping packages against `docs/`, the root `README.md` and the per-package READMEs, **`AbuseTrackerOptions` was the only one mentioned in no tracked doc at all.**
- The sibling showcase packages already document their equivalent knobs inline — `Celerity.Ring`'s README states `VirtualNodesPerNode` (default 160), `Celerity.Cardinality`'s shows `expectedItems: 100_000`. Sentinel was the outlier.

The seven values in the sample are transcribed from the literal field initializers in `src/Celerity.Sentinel/AbuseTrackerOptions.cs`, not from the prose. The `Merge` sentence matches the type's own `<remarks>`: `AbuseTracker.Merge` checks the first-seen setting directly and the underlying `CountMinSketch` / `HyperLogLog` / `BloomFilter` `UnionWith` calls reject mismatched geometry.

## Test plan

- [x] `dotnet build` — succeeds, 0 warnings, 0 errors.
- [x] **The code sample compiles.** Dropped it verbatim into a scratch file in `Celerity.Sentinel.Tests`, built the project (succeeded, 0 warnings), then removed the file — so the object initializer, every property name and every literal type-check against the real API.
- [x] `node scripts/check_doc_anchors.js` — 676 links across 25 files resolve.
- [x] Defaults verified against the field initializers in `AbuseTrackerOptions.cs` one by one.
- [ ] `dotnet test` — not run; the change touches no compiled source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
